### PR TITLE
Patient name improvement

### DIFF
--- a/api/src/main/java/com/lantanagroup/link/api/controller/ReportController.java
+++ b/api/src/main/java/com/lantanagroup/link/api/controller/ReportController.java
@@ -510,14 +510,7 @@ public class ReportController extends BaseController {
         PatientReportModel report = new PatientReportModel();
         Patient patient = (Patient) entry.getResource();
 
-        if (patient.getName().size() > 0) {
-          if (patient.getName().get(0).getFamily() != null) {
-            report.setLastName(patient.getName().get(0).getFamily());
-          }
-          if (patient.getName().get(0).getGiven().size() > 0 && patient.getName().get(0).getGiven().get(0) != null) {
-            report.setFirstName(patient.getName().get(0).getGiven().get(0).toString());
-          }
-        }
+        report.setName(FhirHelper.getName(patient.getName()));
 
         if (patient.getBirthDate() != null) {
           report.setDateOfBirth(Helper.getFhirDate(patient.getBirthDate()));

--- a/core/src/main/java/com/lantanagroup/link/FhirHelper.java
+++ b/core/src/main/java/com/lantanagroup/link/FhirHelper.java
@@ -130,7 +130,7 @@ public class FhirHelper {
         lastName = names.get(0).getFamily();
       }
     } else {
-      return "";
+      return "Unknown";
     }
 
     if (StringUtils.isNotEmpty(firstName) && StringUtils.isNotEmpty(lastName)) {
@@ -141,7 +141,7 @@ public class FhirHelper {
       return firstName;
     }
 
-    return "";
+    return "Unknown";
   }
 
   public static DocumentReference getDocumentReference(IGenericClient client, String reportId) throws HttpResponseException {

--- a/core/src/main/java/com/lantanagroup/link/model/PatientReportModel.java
+++ b/core/src/main/java/com/lantanagroup/link/model/PatientReportModel.java
@@ -6,8 +6,7 @@ import lombok.Setter;
 @Getter @Setter
 public class PatientReportModel {
     String id;
-    String firstName;
-    String lastName;
+    String name;
     String sex;
     String dateOfBirth;
 }

--- a/web/src/main/angular/app/model/report-patient.ts
+++ b/web/src/main/angular/app/model/report-patient.ts
@@ -1,7 +1,6 @@
 export class ReportPatient {
   id: string;
-  firstName: string;
-  lastName: string;
+  name: string;
   sex: string;
   dateOfBirth: string;
 

--- a/web/src/main/angular/app/view-line-level/view-line-level.component.html
+++ b/web/src/main/angular/app/view-line-level/view-line-level.component.html
@@ -10,8 +10,7 @@
     <table class="table table-striped" *ngIf="!loading">
         <thead>
         <tr>
-            <th>First Name</th>
-            <th>Last Name</th>
+            <th>Name</th>
             <th>Sex</th>
             <th>DOB</th>
             <th>&nbsp;</th>
@@ -19,8 +18,7 @@
         </thead>
         <tbody *ngIf="patients?.length">
         <tr *ngFor="let patient of patients">
-            <td>{{patient.firstName}}</td>
-            <td>{{patient.lastName}}</td>
+            <td>{{patient.name}}</td>
             <td>{{patient.sex}}</td>
             <td>{{patient.getDOBDisplay()}}</td>
             <td>
@@ -33,7 +31,7 @@
         </tbody>
         <tfoot *ngIf="!patients?.length">
             <tr>
-                <td colspan="5">No patients in this report</td>
+                <td colspan="4">No patients in this report</td>
             </tr>
         </tfoot>
     </table>

--- a/web/src/main/angular/app/view-line-level/view-line-level.component.ts
+++ b/web/src/main/angular/app/view-line-level/view-line-level.component.ts
@@ -4,6 +4,8 @@ import {ReportService} from '../services/report.service';
 import {ReportPatient} from '../model/report-patient';
 import {ToastService} from '../toast.service';
 import {ViewPatientComponent} from "../view-patient/view-patient.component";
+import {IPatient} from "../fhir";
+import {Patient} from "../model/fhir";
 
 @Component({
   templateUrl: './view-line-level.component.html',


### PR DESCRIPTION
Changing display of patient name to be "last, first" as a single column instead of two separate first+last columns
Re-using `FhirHelper.getName()` from ReportController. Uses Patient.name.text by default, if provided, otherwise uses Patient.name.family + Patient.name.given.