### PR TITLE
Send configured terminology service to CQF-Ruler during $evaluate-measure

### DIFF
--- a/api/src/main/java/com/lantanagroup/link/api/MeasureEvaluator.java
+++ b/api/src/main/java/com/lantanagroup/link/api/MeasureEvaluator.java
@@ -48,6 +48,16 @@ public class MeasureEvaluator {
       parameters.addParameter().setName("periodEnd").setValue(new StringType(this.criteria.getPeriodEnd().substring(0, this.criteria.getPeriodEnd().indexOf("."))));
       parameters.addParameter().setName("subject").setValue(new StringType(patientId));
       parameters.addParameter().setName("additionalData").setResource(patientData.getBundle());
+      if(this.config.getEvaluationService() != this.config.getTerminologyService()) {
+        Endpoint terminologyEndpoint = new Endpoint();
+        terminologyEndpoint.setStatus(Endpoint.EndpointStatus.ACTIVE);
+        terminologyEndpoint.setConnectionType(new Coding());
+        terminologyEndpoint.getConnectionType().setSystem("http://terminology.hl7.org/CodeSystem/endpoint-connection-type");
+        terminologyEndpoint.getConnectionType().setCode("hl7-fhir-rest");
+        terminologyEndpoint.setAddress(this.config.getTerminologyService());
+        parameters.addParameter().setName("terminologyEndpoint").setResource(terminologyEndpoint);
+        logger.info("evaluate-measure is being executed with the terminologyEndpoint parameter.");
+      }
 
       FhirDataProvider fhirDataProvider = new FhirDataProvider(this.config.getEvaluationService());
       measureReport = fhirDataProvider.getMeasureReport(this.context.getMeasureId(), parameters);

--- a/api/src/main/java/com/lantanagroup/link/api/MeasureEvaluator.java
+++ b/api/src/main/java/com/lantanagroup/link/api/MeasureEvaluator.java
@@ -34,6 +34,16 @@ public class MeasureEvaluator {
     return evaluator.generateMeasureReport();
   }
 
+  private static Endpoint getTerminologyEndpoint(ApiConfig config) {
+    Endpoint terminologyEndpoint = new Endpoint();
+    terminologyEndpoint.setStatus(Endpoint.EndpointStatus.ACTIVE);
+    terminologyEndpoint.setConnectionType(new Coding());
+    terminologyEndpoint.getConnectionType().setSystem(Constants.TerminologyEndpointSystem);
+    terminologyEndpoint.getConnectionType().setCode(Constants.TerminologyEndpointCode);
+    terminologyEndpoint.setAddress(config.getTerminologyService());
+    return terminologyEndpoint;
+  }
+
 
   private MeasureReport generateMeasureReport() {
     MeasureReport measureReport;
@@ -48,13 +58,8 @@ public class MeasureEvaluator {
       parameters.addParameter().setName("periodEnd").setValue(new StringType(this.criteria.getPeriodEnd().substring(0, this.criteria.getPeriodEnd().indexOf("."))));
       parameters.addParameter().setName("subject").setValue(new StringType(patientId));
       parameters.addParameter().setName("additionalData").setResource(patientData.getBundle());
-      if(this.config.getEvaluationService() != this.config.getTerminologyService()) {
-        Endpoint terminologyEndpoint = new Endpoint();
-        terminologyEndpoint.setStatus(Endpoint.EndpointStatus.ACTIVE);
-        terminologyEndpoint.setConnectionType(new Coding());
-        terminologyEndpoint.getConnectionType().setSystem("http://terminology.hl7.org/CodeSystem/endpoint-connection-type");
-        terminologyEndpoint.getConnectionType().setCode("hl7-fhir-rest");
-        terminologyEndpoint.setAddress(this.config.getTerminologyService());
+      if(!this.config.getEvaluationService().equals(this.config.getTerminologyService())) {
+        Endpoint terminologyEndpoint = getTerminologyEndpoint(this.config);
         parameters.addParameter().setName("terminologyEndpoint").setResource(terminologyEndpoint);
         logger.info("evaluate-measure is being executed with the terminologyEndpoint parameter.");
       }

--- a/core/src/main/java/com/lantanagroup/link/Constants.java
+++ b/core/src/main/java/com/lantanagroup/link/Constants.java
@@ -17,4 +17,6 @@ public class Constants {
   public static final String ApplicablePeriodExtensionUrl = "https://www.lantanagroup.com/fhir/StructureDefinition/link-patient-list-applicable-period";
   public static final String MeasureReportBundleProfileUrl = "https://www.lantanagroup.com/fhir/StructureDefinition/measure-report-bundle";
   public static final String IdentifierSystem = "urn:ietf:rfc:3986";
+  public static final String TerminologyEndpointCode = "hl7-fhir-rest";
+  public static final String TerminologyEndpointSystem = "http://terminology.hl7.org/CodeSystem/endpoint-connection-type";
 }


### PR DESCRIPTION
Checked to see if ApiConfig.terminologyService and ApiConfig.evaluationService are the same in MeasureEvaluator, if not then created a new endpoint set as active with the Address as the same as the ApiConfig.terminologyService and a connectionType with "http://terminology.hl7.org/CodeSystem/endpoint-connection-type" as its system and "hl7-fhir-rest" as its code. This endpoint was then added as a parameter for getting the measure report.