### PR TITLE
Don't allow discarding reports after submission

### DIFF
--- a/api/src/main/java/com/lantanagroup/link/api/controller/ReportController.java
+++ b/api/src/main/java/com/lantanagroup/link/api/controller/ReportController.java
@@ -827,6 +827,12 @@ public class ReportController extends BaseController {
 
     DocumentReference documentReference = this.getFhirDataProvider().findDocRefForReport(id);
 
+    Extension existingVersionExt = documentReference.getExtensionByUrl(Constants.DocumentReferenceVersionUrl);
+    Float existingVersion = Float.parseFloat(existingVersionExt.getValue().toString());
+    if(existingVersion >= 1.0f) {
+      throw new HttpResponseException(400, "Bad Request, report version is greater than or equal to 1.0");
+    }
+
     // Make sure the bundle is a transaction
     deleteRequest.setType(Bundle.BundleType.TRANSACTION);
     deleteRequest.addEntry().setRequest(new Bundle.BundleEntryRequestComponent());

--- a/web/src/main/angular/app/report/report.component.html
+++ b/web/src/main/angular/app/report/report.component.html
@@ -77,7 +77,7 @@
     <div class="btn-group">
         <button (click)="viewLineLevel()" class="btn btn-primary">View Line-Level Data</button>
         <button (click)="save()" *ngIf="!isSubmitted" [disabled]="!dirty" class="btn btn-primary">Save</button>
-        <button (click)="discard()" *ngIf="!isSubmitted" class="btn btn-primary">
+        <button (click)="discard()" *ngIf="!isSubmitted" [disabled]="repVersionNumber >= 1.0" class="btn btn-primary">
             Discard
         </button>
         <button (click)="send()" *ngIf="!isSubmitted" [disabled]="hasRequiredErrors || submitInProgress" class="btn btn-primary">

--- a/web/src/main/angular/app/report/report.component.ts
+++ b/web/src/main/angular/app/report/report.component.ts
@@ -33,6 +33,10 @@ export class ReportComponent implements OnInit, OnDestroy {
       private router: Router) {
   }
 
+  get repVersionNumber() {
+    return Number(this.report.version);
+  }
+
   get isSubmitted() {
     if (!this.report) return false;
     return this.report.status === 'FINAL';


### PR DESCRIPTION
I added logic to the UI so that it disables the discard button if the report version is greater than or equal to 1.0 and I modified the api to check for the same condition in ReportController.deleteReport() and throw a 400 bad request in such a case.