### PR TITLE
Retrieve census from submission server when re-generating

### DIFF
--- a/api/src/main/java/com/lantanagroup/link/api/controller/ReportController.java
+++ b/api/src/main/java/com/lantanagroup/link/api/controller/ReportController.java
@@ -376,7 +376,7 @@ public class ReportController extends BaseController {
         IReportSender sender = (IReportSender) this.context.getBean(senderClazz);
 
         Bundle submitted = sender.retrieve(config, this.ctx, existingDocumentReference);
-        if(submitted != null) {
+        if(submitted != null && submitted.getEntry().size() > 0) {
           List<ListResource> censusList = new ArrayList<>();
           for(Bundle.BundleEntryComponent entry: submitted.getEntry()) {
             if(entry.getResource().getResourceType() == ResourceType.List) {

--- a/api/src/main/java/com/lantanagroup/link/api/controller/ReportController.java
+++ b/api/src/main/java/com/lantanagroup/link/api/controller/ReportController.java
@@ -189,11 +189,25 @@ public class ReportController extends BaseController {
   }
 
   private List<PatientOfInterestModel> getPatientIdentifiers(ReportCriteria criteria, ReportContext context) throws ClassNotFoundException, NoSuchMethodException, InvocationTargetException, InstantiationException, IllegalAccessException {
-    IPatientIdProvider provider;
-    Class<?> senderClass = Class.forName(this.config.getPatientIdResolver());
-    Constructor<?> patientIdentifierConstructor = senderClass.getConstructor();
-    provider = (IPatientIdProvider) patientIdentifierConstructor.newInstance();
-    return provider.getPatientsOfInterest(criteria, context, this.config);
+    if (context.getPatientCensusLists() != null) {
+      List<PatientOfInterestModel> patientOfInterestModelList = new ArrayList<>();
+      for(ListResource censusList : context.getPatientCensusLists()) {
+        for(ListResource.ListEntryComponent censusPatient : censusList.getEntry()) {
+          PatientOfInterestModel patient = new PatientOfInterestModel(censusPatient.getItem().getReference(),
+                  censusPatient.getItem().getIdentifier().getSystem() + "|" + censusPatient.getItem().getIdentifier().getValue());
+          patientOfInterestModelList.add(patient);
+        }
+      }
+      context.setPatientsOfInterest(patientOfInterestModelList);
+      return patientOfInterestModelList;
+    }
+    else {
+      IPatientIdProvider provider;
+      Class<?> senderClass = Class.forName(this.config.getPatientIdResolver());
+      Constructor<?> patientIdentifierConstructor = senderClass.getConstructor();
+      provider = (IPatientIdProvider) patientIdentifierConstructor.newInstance();
+      return provider.getPatientsOfInterest(criteria, context, this.config);
+    }
   }
 
   private List<QueryResponse> getRemotePatientData(List<PatientOfInterestModel> patientsOfInterest) {
@@ -358,16 +372,20 @@ public class ReportController extends BaseController {
       if (existingDocumentReference != null) {
         existingDocumentReference = FhirHelper.incrementMinorVersion(existingDocumentReference);
 
-        // TODO: if already submitted, get census lists from patient bundle that has been submitted
-
         Class<?> senderClazz = Class.forName(this.config.getSender());
         IReportSender sender = (IReportSender) this.context.getBean(senderClazz);
 
         Bundle submitted = sender.retrieve(config, this.ctx, existingDocumentReference);
+        List<ListResource> censusList = new ArrayList<>();
+        for(Bundle.BundleEntryComponent entry: submitted.getEntry()) {
+          if(entry.getResource().getResourceType() == ResourceType.List) {
+            censusList.add((ListResource)entry.getResource());
+          }
+        }
 
-        // TODO: Find List(s) with measure identifier (representing the census) in bundle
-
-        // TODO: Assign census list to report context
+        if(censusList.size() > 0) {
+          context.setPatientCensusLists(censusList);
+        }
       }
 
       // Generate the master report id

--- a/api/src/main/java/com/lantanagroup/link/api/controller/ReportController.java
+++ b/api/src/main/java/com/lantanagroup/link/api/controller/ReportController.java
@@ -1,5 +1,6 @@
 package com.lantanagroup.link.api.controller;
 
+import ca.uhn.fhir.context.FhirContext;
 import com.lantanagroup.link.Constants;
 import com.lantanagroup.link.*;
 import com.lantanagroup.link.api.ReportGenerator;
@@ -358,6 +359,15 @@ public class ReportController extends BaseController {
         existingDocumentReference = FhirHelper.incrementMinorVersion(existingDocumentReference);
 
         // TODO: if already submitted, get census lists from patient bundle that has been submitted
+
+        Class<?> senderClazz = Class.forName(this.config.getSender());
+        IReportSender sender = (IReportSender) this.context.getBean(senderClazz);
+
+        Bundle submitted = sender.retrieve(config, this.ctx, existingDocumentReference);
+
+        // TODO: Find List(s) with measure identifier (representing the census) in bundle
+
+        // TODO: Assign census list to report context
       }
 
       // Generate the master report id

--- a/api/src/main/java/com/lantanagroup/link/api/controller/ReportController.java
+++ b/api/src/main/java/com/lantanagroup/link/api/controller/ReportController.java
@@ -189,7 +189,7 @@ public class ReportController extends BaseController {
   }
 
   private List<PatientOfInterestModel> getPatientIdentifiers(ReportCriteria criteria, ReportContext context) throws ClassNotFoundException, NoSuchMethodException, InvocationTargetException, InstantiationException, IllegalAccessException {
-    if (context.getPatientCensusLists() != null) {
+    if (context.getPatientCensusLists() != null && context.getPatientCensusLists().size() > 0) {
       List<PatientOfInterestModel> patientOfInterestModelList = new ArrayList<>();
       for(ListResource censusList : context.getPatientCensusLists()) {
         for(ListResource.ListEntryComponent censusPatient : censusList.getEntry()) {
@@ -376,15 +376,17 @@ public class ReportController extends BaseController {
         IReportSender sender = (IReportSender) this.context.getBean(senderClazz);
 
         Bundle submitted = sender.retrieve(config, this.ctx, existingDocumentReference);
-        List<ListResource> censusList = new ArrayList<>();
-        for(Bundle.BundleEntryComponent entry: submitted.getEntry()) {
-          if(entry.getResource().getResourceType() == ResourceType.List) {
-            censusList.add((ListResource)entry.getResource());
+        if(submitted != null) {
+          List<ListResource> censusList = new ArrayList<>();
+          for(Bundle.BundleEntryComponent entry: submitted.getEntry()) {
+            if(entry.getResource().getResourceType() == ResourceType.List) {
+              censusList.add((ListResource)entry.getResource());
+            }
           }
-        }
 
-        if(censusList.size() > 0) {
-          context.setPatientCensusLists(censusList);
+          if(censusList.size() > 0) {
+            context.setPatientCensusLists(censusList);
+          }
         }
       }
 

--- a/api/src/main/java/com/lantanagroup/link/api/controller/ReportController.java
+++ b/api/src/main/java/com/lantanagroup/link/api/controller/ReportController.java
@@ -381,12 +381,10 @@ public class ReportController extends BaseController {
           for(Bundle.BundleEntryComponent entry: submitted.getEntry()) {
             if(entry.getResource().getResourceType() == ResourceType.List) {
               censusList.add((ListResource)entry.getResource());
+              this.getFhirDataProvider().updateResource(entry.getResource());
             }
           }
-
-          if(censusList.size() > 0) {
-            context.setPatientCensusLists(censusList);
-          }
+          context.setPatientCensusLists(censusList);
         }
       }
 

--- a/core/src/main/java/com/lantanagroup/link/GenericSender.java
+++ b/core/src/main/java/com/lantanagroup/link/GenericSender.java
@@ -1,6 +1,9 @@
 package com.lantanagroup.link;
 
+import ca.uhn.fhir.context.FhirContext;
 import com.lantanagroup.link.auth.OAuth2Helper;
+import com.lantanagroup.link.config.api.ApiConfig;
+import com.lantanagroup.link.config.auth.LinkOAuthConfig;
 import com.lantanagroup.link.config.sender.FHIRSenderConfig;
 import com.lantanagroup.link.config.sender.FhirSenderUrlOAuthConfig;
 import lombok.Setter;
@@ -26,6 +29,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpRequest;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.zip.GZIPOutputStream;
@@ -145,6 +150,43 @@ public abstract class GenericSender {
       }
     }
     return location;
+  }
+
+  public Bundle retrieveContent(ApiConfig apiConfig, FhirContext fhirContext, DocumentReference existingDocumentReference) {
+    java.net.http.HttpClient client = java.net.http.HttpClient.newHttpClient();
+    String bundleLocation = FhirHelper.getFirstDocumentReferenceLocation(existingDocumentReference);
+    if(bundleLocation != null && !bundleLocation.equals("")) {
+      HttpRequest.Builder requestBuilder = HttpRequest.newBuilder()
+              .uri(URI.create(bundleLocation));
+
+      LinkOAuthConfig authConfig = apiConfig.getReportDefs().getAuth();
+      if (authConfig != null) {
+        try {
+          String token = OAuth2Helper.getToken(authConfig);
+          requestBuilder.setHeader("Authorization", "Bearer " + token);
+        } catch (Exception ex) {
+          logger.error(String.format("Error generating authorization token: %s", ex.getMessage()));
+          return null;
+        }
+      }
+      requestBuilder.GET();
+      HttpRequest submissionReq = requestBuilder.build();
+
+      java.net.http.HttpResponse<String> response = null;
+      try {
+        response = client
+                .send(submissionReq, java.net.http.HttpResponse.BodyHandlers.ofString());
+      } catch (IOException e) {
+        e.printStackTrace();
+      } catch (InterruptedException e) {
+        e.printStackTrace();
+      }
+
+      if(response != null) {
+        return (Bundle) fhirContext.newJsonParser().parseResource(response.body());
+      }
+    }
+    return new Bundle();
   }
 
   public void updateDocumentLocation(MeasureReport masterMeasureReport, FhirDataProvider fhirDataProvider, String location) {

--- a/core/src/main/java/com/lantanagroup/link/GenericSender.java
+++ b/core/src/main/java/com/lantanagroup/link/GenericSender.java
@@ -27,6 +27,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.zip.GZIPOutputStream;
 
 public abstract class GenericSender {
@@ -57,6 +58,10 @@ public abstract class GenericSender {
 
 
   public abstract String bundle(Bundle bundle, FhirDataProvider fhirProvider);
+
+  public List<FhirSenderUrlOAuthConfig> getSendLocations() {
+    return this.config.getSendUrls();
+  }
 
   public String sendContent(MeasureReport masterMeasureReport, FhirDataProvider fhirProvider, String mimeType,
                             boolean sendWholeBundle, boolean removeGeneratedObservations) throws Exception {

--- a/core/src/main/java/com/lantanagroup/link/GenericSender.java
+++ b/core/src/main/java/com/lantanagroup/link/GenericSender.java
@@ -124,8 +124,8 @@ public abstract class GenericSender {
           throw new HttpResponseException(500, "Internal Server Error");
         }
 
-        if (response.getHeaders("Location") != null && response.getHeaders("Location").length > 0) {
-          location = response.getHeaders("Location")[0].getElements()[0].getName();
+        if (response.getHeaders("Content-Location") != null && response.getHeaders("Content-Location").length > 0) {
+          location = response.getHeaders("Content-Location")[0].getElements()[0].getName();
           if (location.indexOf("/_history/") > 0) {
             location = location.substring(0, location.indexOf("/_history/"));
           }

--- a/core/src/main/java/com/lantanagroup/link/GenericSender.java
+++ b/core/src/main/java/com/lantanagroup/link/GenericSender.java
@@ -147,11 +147,18 @@ public abstract class GenericSender {
     return location;
   }
 
-  public void updateDocumentLocation(MeasureReport masterMeasureReport, FhirDataProvider fhirDataProvider, String
-          location) {
+  public void updateDocumentLocation(MeasureReport masterMeasureReport, FhirDataProvider fhirDataProvider, String location) {
     String reportID = masterMeasureReport.getIdElement().getIdPart();
     DocumentReference documentReference = fhirDataProvider.findDocRefForReport(reportID);
     if (documentReference != null) {
+      String previousLocation = FhirHelper.getFirstDocumentReferenceLocation(documentReference);
+      if(previousLocation != null && !previousLocation.equals("")) {
+        for (int index = documentReference.getContent().size() - 1; index > -1; index--) {
+          if (documentReference.getContent().get(index).hasAttachment() && documentReference.getContent().get(index).getAttachment().hasUrl()) {
+            documentReference.getContent().remove(index);
+          }
+        }
+      }
       documentReference.getContent().add(new DocumentReference.DocumentReferenceContentComponent());
       Attachment attachment = new Attachment();
       attachment.setUrl(location);

--- a/core/src/main/java/com/lantanagroup/link/IReportSender.java
+++ b/core/src/main/java/com/lantanagroup/link/IReportSender.java
@@ -1,5 +1,9 @@
 package com.lantanagroup.link;
 
+import ca.uhn.fhir.context.FhirContext;
+import com.lantanagroup.link.config.api.ApiConfig;
+import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.DocumentReference;
 import org.hl7.fhir.r4.model.MeasureReport;
 import org.springframework.security.core.Authentication;
 
@@ -7,4 +11,6 @@ import javax.servlet.http.HttpServletRequest;
 
 public interface IReportSender {
   void send(MeasureReport masterMeasureReport, HttpServletRequest request, Authentication auth, FhirDataProvider fhirDataProvider, Boolean sendWholeBundle, boolean removeGeneratedObservations) throws Exception;
+
+  Bundle retrieve(ApiConfig config, FhirContext fhirContext, DocumentReference existingDocumentReference);
 }

--- a/core/src/main/java/com/lantanagroup/link/IReportSender.java
+++ b/core/src/main/java/com/lantanagroup/link/IReportSender.java
@@ -12,5 +12,13 @@ import javax.servlet.http.HttpServletRequest;
 public interface IReportSender {
   void send(MeasureReport masterMeasureReport, HttpServletRequest request, Authentication auth, FhirDataProvider fhirDataProvider, Boolean sendWholeBundle, boolean removeGeneratedObservations) throws Exception;
 
+  /**
+   * Looks up submission location from document reference to send a request for the previously submitted bundle which is returns
+   *
+   * @param config used to authenticate based on configuration and attach authentication token to submission request
+   * @param fhirContext used to parse the content body of the response from the submission request into a bundle to return
+   * @param existingDocumentReference used to look up the address of where the previous submission was sent
+   * @return returns the submission bundle that was previously sent
+   */
   Bundle retrieve(ApiConfig config, FhirContext fhirContext, DocumentReference existingDocumentReference);
 }

--- a/nhsn/src/main/java/com/lantanagroup/link/nhsn/FHIRSender.java
+++ b/nhsn/src/main/java/com/lantanagroup/link/nhsn/FHIRSender.java
@@ -41,40 +41,7 @@ public class FHIRSender extends GenericSender implements IReportSender {
 
   @Override
   public Bundle retrieve(ApiConfig apiConfig, FhirContext fhirContext, DocumentReference existingDocumentReference) {
-    HttpClient client = HttpClient.newHttpClient();
-    String bundleLocation = FhirHelper.getFirstDocumentReferenceLocation(existingDocumentReference);
-    if(bundleLocation != null && !bundleLocation.equals("")) {
-      HttpRequest.Builder requestBuilder = HttpRequest.newBuilder()
-              .uri(URI.create(bundleLocation));
-
-      LinkOAuthConfig authConfig = apiConfig.getReportDefs().getAuth();
-      if (authConfig != null) {
-        try {
-          String token = OAuth2Helper.getToken(authConfig);
-          requestBuilder.setHeader("Authorization", "Bearer " + token);
-        } catch (Exception ex) {
-          logger.error(String.format("Error generating authorization token: %s", ex.getMessage()));
-          return null;
-        }
-      }
-      requestBuilder.GET();
-      HttpRequest submissionReq = requestBuilder.build();
-
-      HttpResponse<String> response = null;
-      try {
-        response = client
-                .send(submissionReq, HttpResponse.BodyHandlers.ofString());
-      } catch (IOException e) {
-        e.printStackTrace();
-      } catch (InterruptedException e) {
-        e.printStackTrace();
-      }
-
-      if(response != null) {
-        return (Bundle) fhirContext.newJsonParser().parseResource(response.body());
-      }
-    }
-    return null;
+    return retrieveContent(apiConfig, fhirContext, existingDocumentReference);
   }
 
   public String bundle(Bundle bundle, FhirDataProvider fhirDataProvider) {

--- a/nhsn/src/main/java/com/lantanagroup/link/nhsn/FHIRSender.java
+++ b/nhsn/src/main/java/com/lantanagroup/link/nhsn/FHIRSender.java
@@ -1,11 +1,17 @@
 package com.lantanagroup.link.nhsn;
 
+import ca.uhn.fhir.context.FhirContext;
 import com.lantanagroup.link.FhirDataProvider;
 import com.lantanagroup.link.FhirHelper;
 import com.lantanagroup.link.GenericSender;
 import com.lantanagroup.link.IReportSender;
 import com.lantanagroup.link.auth.LinkCredentials;
+import com.lantanagroup.link.auth.OAuth2Helper;
+import com.lantanagroup.link.config.api.ApiConfig;
+import com.lantanagroup.link.config.auth.LinkOAuthConfig;
+import com.lantanagroup.link.config.sender.FhirSenderUrlOAuthConfig;
 import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.DocumentReference;
 import org.hl7.fhir.r4.model.MeasureReport;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -13,6 +19,9 @@ import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
 
 import javax.servlet.http.HttpServletRequest;
+import java.net.URI;
+import java.net.http.HttpRequest;
+import java.util.List;
 
 
 @Component
@@ -25,6 +34,44 @@ public class FHIRSender extends GenericSender implements IReportSender {
     sendContent(masterMeasureReport, fhirDataProvider, "application/xml", sendWholeBundle, removeGeneratedObservations);
 
     FhirHelper.recordAuditEvent(request, fhirDataProvider, ((LinkCredentials) auth.getPrincipal()).getJwt(), FhirHelper.AuditEventTypes.Send, "Successfully sent report");
+  }
+
+  @Override
+  public Bundle retrieve(ApiConfig apiConfig, FhirContext fhirContext, DocumentReference existingDocumentReference) {
+    String submittedUrl = existingDocumentReference.getContent().get(0).getAttachment().getUrl();
+    if(submittedUrl != null) {
+      HttpRequest.Builder requestBuilder = HttpRequest.newBuilder()
+              .uri(URI.create(submittedUrl));
+      //.setHeader("if-modified-since", lastUpdateDate);
+
+      LinkOAuthConfig authConfig = apiConfig.getReportDefs().getAuth();
+      if (authConfig != null) {
+        try {
+          String token = OAuth2Helper.getToken(authConfig);
+          requestBuilder.setHeader("Authorization", "Bearer " + token);
+        } catch (Exception ex) {
+          logger.error(String.format("Error generating authorization token: %s", ex.getMessage()));
+          return null;
+        }
+      }
+
+      HttpRequest submissionReq = requestBuilder.build();
+      // TODO: Authenticate based on configuration
+      // TODO: Attach authentication token to submissionReq
+      //HttpResponse submissionRes = submissionReq.getResponse();
+      // TODO: Read response
+    /*FHIRReceiver receiver = new FHIRReceiver();
+    String bundleLocation = FhirHelper.getFirstDocumentReferenceLocation(existingDocumentReference);
+    String content = null;
+    try {
+      content = receiver.retrieveContent(bundleLocation);
+    } catch (Exception e) {
+      e.printStackTrace();
+    }*/
+    }
+
+    //return (Bundle) fhirContext.newJsonParser().parseResource(content);
+    return new Bundle();
   }
 
   public String bundle(Bundle bundle, FhirDataProvider fhirDataProvider) {

--- a/nhsn/src/main/java/com/lantanagroup/link/nhsn/FHIRSender.java
+++ b/nhsn/src/main/java/com/lantanagroup/link/nhsn/FHIRSender.java
@@ -43,7 +43,7 @@ public class FHIRSender extends GenericSender implements IReportSender {
   public Bundle retrieve(ApiConfig apiConfig, FhirContext fhirContext, DocumentReference existingDocumentReference) {
     HttpClient client = HttpClient.newHttpClient();
     String bundleLocation = FhirHelper.getFirstDocumentReferenceLocation(existingDocumentReference);
-    if(bundleLocation != null) {
+    if(bundleLocation != null && !bundleLocation.equals("")) {
       HttpRequest.Builder requestBuilder = HttpRequest.newBuilder()
               .uri(URI.create(bundleLocation));
 

--- a/nhsn/src/main/java/com/lantanagroup/link/nhsn/JSONSender.java
+++ b/nhsn/src/main/java/com/lantanagroup/link/nhsn/JSONSender.java
@@ -1,11 +1,14 @@
 package com.lantanagroup.link.nhsn;
 
+import ca.uhn.fhir.context.FhirContext;
 import com.lantanagroup.link.FhirDataProvider;
 import com.lantanagroup.link.FhirHelper;
 import com.lantanagroup.link.GenericSender;
 import com.lantanagroup.link.IReportSender;
 import com.lantanagroup.link.auth.LinkCredentials;
+import com.lantanagroup.link.config.api.ApiConfig;
 import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.DocumentReference;
 import org.hl7.fhir.r4.model.MeasureReport;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -24,6 +27,11 @@ public class JSONSender extends GenericSender implements IReportSender {
     this.sendContent(masterMeasureReport, fhirDataProvider, "application/json", sendWholeBundle, removeGeneratedObservations);
 
     FhirHelper.recordAuditEvent(request, fhirDataProvider, ((LinkCredentials) auth.getPrincipal()).getJwt(), FhirHelper.AuditEventTypes.Send, "Successfully sent report");
+  }
+
+  @Override
+  public Bundle retrieve(ApiConfig config, FhirContext fhirContext, DocumentReference existingDocumentReference) {
+    return null;
   }
 
   public String bundle(Bundle bundle, FhirDataProvider fhirDataProvider) {

--- a/nhsn/src/main/java/com/lantanagroup/link/nhsn/JSONSender.java
+++ b/nhsn/src/main/java/com/lantanagroup/link/nhsn/JSONSender.java
@@ -30,8 +30,8 @@ public class JSONSender extends GenericSender implements IReportSender {
   }
 
   @Override
-  public Bundle retrieve(ApiConfig config, FhirContext fhirContext, DocumentReference existingDocumentReference) {
-    return null;
+  public Bundle retrieve(ApiConfig apiConfig, FhirContext fhirContext, DocumentReference existingDocumentReference) {
+    return retrieveContent(apiConfig, fhirContext, existingDocumentReference);
   }
 
   public String bundle(Bundle bundle, FhirDataProvider fhirDataProvider) {

--- a/thsa/src/main/java/com/lantanagroup/link/thsa/CSVSender.java
+++ b/thsa/src/main/java/com/lantanagroup/link/thsa/CSVSender.java
@@ -32,8 +32,8 @@ public class CSVSender extends GenericSender implements IReportSender {
   }
 
   @Override
-  public Bundle retrieve(ApiConfig config, FhirContext fhirContext, DocumentReference existingDocumentReference) {
-    return null;
+  public Bundle retrieve(ApiConfig apiConfig, FhirContext fhirContext, DocumentReference existingDocumentReference) {
+    return retrieveContent(apiConfig, fhirContext, existingDocumentReference);
   }
 
 

--- a/thsa/src/main/java/com/lantanagroup/link/thsa/CSVSender.java
+++ b/thsa/src/main/java/com/lantanagroup/link/thsa/CSVSender.java
@@ -1,11 +1,14 @@
 package com.lantanagroup.link.thsa;
 
+import ca.uhn.fhir.context.FhirContext;
 import com.lantanagroup.link.FhirDataProvider;
 import com.lantanagroup.link.FhirHelper;
 import com.lantanagroup.link.GenericSender;
 import com.lantanagroup.link.IReportSender;
 import com.lantanagroup.link.auth.LinkCredentials;
+import com.lantanagroup.link.config.api.ApiConfig;
 import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.DocumentReference;
 import org.hl7.fhir.r4.model.MeasureReport;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -26,6 +29,11 @@ public class CSVSender extends GenericSender implements IReportSender {
     this.sendContent(masterMeasureReport, fhirDataProvider, "text/csv", sendWholeBundle, removeGeneratedObservations);
 
     FhirHelper.recordAuditEvent(request, fhirDataProvider, ((LinkCredentials) auth.getPrincipal()).getJwt(), FhirHelper.AuditEventTypes.Send, "Successfully sent report");
+  }
+
+  @Override
+  public Bundle retrieve(ApiConfig config, FhirContext fhirContext, DocumentReference existingDocumentReference) {
+    return null;
   }
 
 


### PR DESCRIPTION
Created functionality to retrieve the patient census list from the submission bundle that was retrieved from the sent location that was added to the doc reference during the last submission. The census list is then added to the dev server and the report context where it is used to populate a list of patients of interest instead of looking them up from the server.