### PR TITLE
Extend Coding used by ConceptMapping to preserve original value before translation

### DIFF
--- a/core/src/main/java/com/lantanagroup/link/nhsn/ApplyConceptMaps.java
+++ b/core/src/main/java/com/lantanagroup/link/nhsn/ApplyConceptMaps.java
@@ -7,6 +7,7 @@ import com.lantanagroup.link.model.ReportContext;
 import com.lantanagroup.link.model.ReportCriteria;
 import org.hl7.fhir.r4.model.Coding;
 import org.hl7.fhir.r4.model.ConceptMap;
+import org.hl7.fhir.r4.model.Extension;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -18,11 +19,16 @@ public class ApplyConceptMaps implements IReportGenerationEvent {
   private static final Logger logger = LoggerFactory.getLogger(ApplyConceptMaps.class);
 
 
-  private void getConvertCode(ConceptMap map, Coding code) {
+  private void applyMap(ConceptMap map, Coding code) {
     // TODO: Lookup ConceptMap.group based on code system
     map.getGroup().stream().forEach((ConceptMap.ConceptMapGroupComponent group) -> {
       if (group.getSource().equals(code.getSystem())) {
         List<ConceptMap.SourceElementComponent> elements = group.getElement().stream().filter(elem -> elem.getCode().equals(code.getCode())).collect(Collectors.toList());
+        // preserve original code
+        Extension originalCode = new Extension();
+        originalCode.setUrl("https://www.lantanagroup.com/fhir/StructureDefinition/mapped-concept");
+        originalCode.setValue(code);
+        code.getExtension().add(originalCode);
         // pick the last element from list
         code.setSystem(group.getTarget());
         code.setDisplay(elements.get(elements.size() - 1).getTarget().get(0).getDisplay());
@@ -41,8 +47,8 @@ public class ApplyConceptMaps implements IReportGenerationEvent {
       if (!conceptMapsList.isEmpty()) {
         List<Coding> codes = ResourceIdChanger.findCodings(patientQueryResponse);
         conceptMapsList.stream().forEach(conceptMap -> {
-          codes.stream().forEach(code -> {
-            this.getConvertCode(conceptMap, code);
+          codes.parallelStream().forEach(code -> {
+            this.applyMap(conceptMap, code);
           });
         });
       }


### PR DESCRIPTION
I modified ApplyConceptMaps to add an extension with the original code to the code before the code gets its new values from the concept map.