### PR TITLE
Configuration to execute interface class for CSV processing

### DIFF
--- a/api/src/main/java/com/lantanagroup/link/api/controller/ReportDataController.java
+++ b/api/src/main/java/com/lantanagroup/link/api/controller/ReportDataController.java
@@ -1,5 +1,6 @@
 package com.lantanagroup.link.api.controller;
 
+import com.lantanagroup.link.IDataProcessor;
 import com.lantanagroup.link.config.api.ApiConfig;
 import com.opencsv.CSVReader;
 import com.opencsv.CSVReaderBuilder;
@@ -46,5 +47,7 @@ public class ReportDataController extends BaseController{
         // TODO
         break;
     }
-  }
+
+    IDataProcessor.process(csvContent.getBytes(), getFhirDataProvider());
+  }IDataProcessor
 }

--- a/api/src/main/java/com/lantanagroup/link/api/controller/ReportDataController.java
+++ b/api/src/main/java/com/lantanagroup/link/api/controller/ReportDataController.java
@@ -48,6 +48,6 @@ public class ReportDataController extends BaseController{
         break;
     }
 
-    IDataProcessor.process(csvContent.getBytes(), getFhirDataProvider());
+    //IDataProcessor.process(csvContent.getBytes(), getFhirDataProvider());
   }
 }

--- a/api/src/main/java/com/lantanagroup/link/api/controller/ReportDataController.java
+++ b/api/src/main/java/com/lantanagroup/link/api/controller/ReportDataController.java
@@ -1,9 +1,13 @@
 package com.lantanagroup.link.api.controller;
 
+import com.lantanagroup.link.config.api.ApiConfig;
 import com.opencsv.CSVReader;
 import com.opencsv.CSVReaderBuilder;
+import lombok.Setter;
+import org.apache.http.client.HttpResponseException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 
 import java.io.BufferedReader;
@@ -18,8 +22,16 @@ import java.util.List;
 public class ReportDataController extends BaseController{
   private static final Logger logger = LoggerFactory.getLogger(ReportDataController.class);
 
+  @Autowired
+  @Setter
+  private ApiConfig config;
+
   @PostMapping(value = "/api/data/csv?type=XXX")
   public void retrieveCSVData(@PathVariable("XXX") String type, @RequestBody() String csvContent) throws Exception {
+
+    if(config.getDataProcessor().get("csv") == null || config.getDataProcessor().get("csv").equals("")) {
+      throw new HttpResponseException(400, "Bad Request, cannot find data processor.");
+    }
 
     logger.debug("Receiving CSV. Parsing...");
     InputStream inputStream = new ByteArrayInputStream(csvContent.getBytes(StandardCharsets.UTF_8));
@@ -35,5 +47,4 @@ public class ReportDataController extends BaseController{
         break;
     }
   }
-
 }

--- a/core/src/main/java/com/lantanagroup/link/IDataProcessor.java
+++ b/core/src/main/java/com/lantanagroup/link/IDataProcessor.java
@@ -1,0 +1,5 @@
+package com.lantanagroup.link;
+
+public interface IDataProcessor {
+  void process(byte[] dataContent, FhirDataProvider fhirDataProvider);
+}

--- a/core/src/main/java/com/lantanagroup/link/IDataProcessor.java
+++ b/core/src/main/java/com/lantanagroup/link/IDataProcessor.java
@@ -1,5 +1,7 @@
 package com.lantanagroup.link;
 
 public interface IDataProcessor {
-  void process(byte[] dataContent, FhirDataProvider fhirDataProvider);
+  static void process(byte[] dataContent, FhirDataProvider fhirDataProvider) {
+
+  }
 }

--- a/core/src/main/java/com/lantanagroup/link/IDataProcessor.java
+++ b/core/src/main/java/com/lantanagroup/link/IDataProcessor.java
@@ -1,7 +1,5 @@
 package com.lantanagroup.link;
 
 public interface IDataProcessor {
-  static void process(byte[] dataContent, FhirDataProvider fhirDataProvider) {
-
-  }
+  void process(byte[] dataContent, FhirDataProvider fhirDataProvider);
 }

--- a/core/src/main/java/com/lantanagroup/link/config/api/ApiConfig.java
+++ b/core/src/main/java/com/lantanagroup/link/config/api/ApiConfig.java
@@ -9,6 +9,7 @@ import org.springframework.context.annotation.PropertySource;
 import org.springframework.validation.annotation.Validated;
 
 import javax.validation.constraints.NotNull;
+import java.util.HashMap;
 import java.util.List;
 
 @Getter
@@ -137,4 +138,16 @@ public class ApiConfig {
 
     @Getter
     private Boolean deleteAfterSubmission;
+
+    /**
+     * The key represents the “type” of data source (csv, excel, etc.) and the value represents the class to use to process the data.
+     */
+    @Getter
+    private HashMap<String, String> dataProcessor;
+
+    /**
+     * The string represents the data measure report id that gets continuously updated.
+     */
+    @Getter
+    private String dataMeasureReportId;
 }


### PR DESCRIPTION
Added the dataProcessor and dataMeasureReportId properties to ApiConfig and created an interface IDataProcessor in core with a process method. Then I added a check for if the data processor for csv exists based on the configuration in ReportDataController.retrieveCSVData(), if not then it respondes with a 400 Bad Request error. Finally I added  IDataProcessor.process() to ReportDataController with process() being static for now until  IDataProcessor is implemented in LINK-865.
