### PR TITLE
LINK-943

### DIFF
--- a/core/src/main/java/com/lantanagroup/link/Constants.java
+++ b/core/src/main/java/com/lantanagroup/link/Constants.java
@@ -20,4 +20,5 @@ public class Constants {
   public static final String TerminologyEndpointCode = "hl7-fhir-rest";
   public static final String TerminologyEndpointSystem = "http://terminology.hl7.org/CodeSystem/endpoint-connection-type";
   public static final String ConceptMappingExtension = "https://www.lantanagroup.com/fhir/StructureDefinition/mapped-concept";
+  public static final String ExtensionPopulationReference = "http://hl7.org/fhir/us/davinci-deqm/StructureDefinition/extension-populationReference";
 }

--- a/core/src/main/java/com/lantanagroup/link/FhirDataProvider.java
+++ b/core/src/main/java/com/lantanagroup/link/FhirDataProvider.java
@@ -233,7 +233,13 @@ public class FhirDataProvider {
             .execute();
   }
 
-  public IBaseResource getResource(String resourceType, String resourceId) {
+  /**
+   * Gets a resource by type and ID only including the id property to check if the resource exists
+   * @param resourceType
+   * @param resourceId
+   * @return
+   */
+  public IBaseResource tryGetResource(String resourceType, String resourceId) {
     return this.client
             .read()
             .resource(resourceType)
@@ -243,6 +249,12 @@ public class FhirDataProvider {
             .execute();
   }
 
+  /**
+   * Gets a complete resource by retrieving it based on type and id
+   * @param resourceType
+   * @param resourceId
+   * @return
+   */
   public IBaseResource getResourceByTypeAndId(String resourceType, String resourceId) {
     return this.client
             .read()


### PR DESCRIPTION
Bundling resources from patient data bundles instead of expecting the individual resources to be stored on the internal FHIR server

Filtering to only include evaluatedResources in the bundle that have the `extension-populationReference` extension