### PR TITLE
Refactor properties into USCoreConfig

### DIFF
--- a/api/src/main/java/com/lantanagroup/link/api/ApiInit.java
+++ b/api/src/main/java/com/lantanagroup/link/api/ApiInit.java
@@ -11,6 +11,7 @@ import com.lantanagroup.link.auth.OAuth2Helper;
 import com.lantanagroup.link.config.api.ApiConfig;
 import com.lantanagroup.link.config.auth.LinkOAuthConfig;
 import com.lantanagroup.link.config.query.QueryConfig;
+import com.lantanagroup.link.config.query.USCoreConfig;
 import org.apache.logging.log4j.util.Strings;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r4.model.Bundle;
@@ -43,6 +44,9 @@ public class ApiInit {
 
   @Autowired
   private QueryConfig queryConfig;
+
+  @Autowired
+  private USCoreConfig usCoreConfig;
 
   @Autowired
   private FhirDataProvider provider;
@@ -150,7 +154,7 @@ public class ApiInit {
         return;
       }
 
-      String missingResourceTypes = FhirHelper.getQueryConfigurationDataReqMissingResourceTypes(FhirHelper.getQueryConfigurationResourceTypes(queryConfig), measureDefBundle);
+      String missingResourceTypes = FhirHelper.getQueryConfigurationDataReqMissingResourceTypes(FhirHelper.getQueryConfigurationResourceTypes(usCoreConfig), measureDefBundle);
       if (!missingResourceTypes.equals("")) {
         logger.error(String.format("These resource types %s are in data requirements for %s but missing from the configuration.", missingResourceTypes, measureDefUrl));
        // return;

--- a/api/src/main/java/com/lantanagroup/link/api/controller/ReportController.java
+++ b/api/src/main/java/com/lantanagroup/link/api/controller/ReportController.java
@@ -10,6 +10,7 @@ import com.lantanagroup.link.config.api.ApiConfigEvents;
 import com.lantanagroup.link.config.api.ApiQueryConfigModes;
 import com.lantanagroup.link.config.auth.LinkOAuthConfig;
 import com.lantanagroup.link.config.query.QueryConfig;
+import com.lantanagroup.link.config.query.USCoreConfig;
 import com.lantanagroup.link.config.thsa.THSAConfig;
 import com.lantanagroup.link.model.*;
 import com.lantanagroup.link.nhsn.FHIRReceiver;
@@ -65,6 +66,8 @@ public class ReportController extends BaseController {
   @Setter
   private THSAConfig thsaConfig;
 
+  @Autowired
+  private USCoreConfig usCoreConfig;
 
   @Autowired
   @Setter
@@ -164,7 +167,7 @@ public class ReportController extends BaseController {
       if (reportRemoteReportDefBundle == null) {
         logger.error(String.format("Error parsing report def bundle from %s", url));
       } else {
-        missingResourceTypes = FhirHelper.getQueryConfigurationDataReqMissingResourceTypes(FhirHelper.getQueryConfigurationResourceTypes(queryConfig), reportRemoteReportDefBundle);
+        missingResourceTypes = FhirHelper.getQueryConfigurationDataReqMissingResourceTypes(FhirHelper.getQueryConfigurationResourceTypes(usCoreConfig), reportRemoteReportDefBundle);
         if (!missingResourceTypes.equals("")) {
           logger.error(String.format("These resource types %s are in data requirements but missing from the configuration.", missingResourceTypes));
         }
@@ -426,7 +429,7 @@ public class ReportController extends BaseController {
       triggerEvent(EventTypes.AfterPatientOfInterestLookup, criteria, context);
 
       // Get the resource types to query
-      List<String> resourceTypesToQuery = FhirHelper.getQueryConfigurationDataReqCommonResourceTypes(queryConfig.getPatientResourceTypes(), context.getReportDefBundle());
+      List<String> resourceTypesToQuery = FhirHelper.getQueryConfigurationDataReqCommonResourceTypes(usCoreConfig.getPatientResourceTypes(), context.getReportDefBundle());
 
       // Scoop the data for the patients and store it
       context.getPatientData().addAll(this.queryAndStorePatientData(patientsOfInterest, resourceTypesToQuery, criteria, context, id));

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -41,17 +41,26 @@ thsa:
   dataMeasureReportId: inventorydata
 query:
   require-https: true
-  parallel-patients: 10
   query-class: com.lantanagroup.link.query.uscore.Query
-  uscore:
-    queries:
-      - Encounter?patient=Patient/{{patientId}}
-      - Condition?patient=Patient/{{patientId}}
-      - MedicationRequest?patient=Patient/{{patientId}}
-      - Observation?category=laboratory&patient=Patient/{{patientId}}
-      - Procedure?patient=Patient/{{patientId}}
-      - ServiceRequest?patient=Patient/{{patientId}}
-      - Coverage?patient=Patient/{{patientId}}
-    additional-resources:
-      - Location/{{locationId}}
-      - Medication/{{medicationId}}
+  fhir-server-base: https://ehr-test.nhsnlink.org/fhir
+  proxy-address: 23i90u4akdjsf
+  allowed-remote:
+    - testbadip
+    - 0:0:0:0:0:0:0:1
+    - 127.0.0.1
+    - dev-api.nhsnlink.org
+    - test-api.nhsnlink.org
+  api-key: 89a83764-9530-4340-9a14-1058b9e84f84c977f983-46e3-4e49-9c3b-869bb2b0f5328ba571b9-e785-4a0b-9fdd-5ff34b8125c47859d241-4ccc-406a-96b6-6fdc918a05e6f3288ebd-927c-4db5
+uscore:
+  patient-resource-types:
+    - Encounter?patient=Patient/{{patientId}}
+    - Condition?patient=Patient/{{patientId}}
+    - MedicationRequest?patient=Patient/{{patientId}}
+    - Observation?category=laboratory&patient=Patient/{{patientId}}
+    - Procedure?patient=Patient/{{patientId}}
+    - ServiceRequest?patient=Patient/{{patientId}}
+    - Coverage?patient=Patient/{{patientId}}
+  additional-resources:
+    - Location/{{locationId}}
+    - Medication/{{medicationId}}
+  parallel-patients: 10

--- a/core/src/main/java/com/lantanagroup/link/FhirHelper.java
+++ b/core/src/main/java/com/lantanagroup/link/FhirHelper.java
@@ -11,6 +11,7 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.lantanagroup.link.config.api.ApiConfig;
 import com.lantanagroup.link.config.query.QueryConfig;
+import com.lantanagroup.link.config.query.USCoreConfig;
 import com.lantanagroup.link.model.PatientReportModel;
 import com.lantanagroup.link.serialize.FhirJsonDeserializer;
 import com.lantanagroup.link.serialize.FhirJsonSerializer;
@@ -512,8 +513,8 @@ public class FhirHelper {
     return reportDefBundleDataReqSet.stream().filter(properties::contains).collect(Collectors.toList());
   }
 
-  public static List<String> getQueryConfigurationResourceTypes(QueryConfig queryConfig) {
-    return Helper.concatenate(queryConfig.getPatientResourceTypes(), queryConfig.getOtherResourceTypes());
+  public static List<String> getQueryConfigurationResourceTypes(USCoreConfig usCoreConfig) {
+    return Helper.concatenate(usCoreConfig.getPatientResourceTypes(), usCoreConfig.getOtherResourceTypes());
   }
 
   public static String getDocumentReferenceLocationByUrl(DocumentReference documentReference, String url) {

--- a/core/src/main/java/com/lantanagroup/link/config/query/QueryConfig.java
+++ b/core/src/main/java/com/lantanagroup/link/config/query/QueryConfig.java
@@ -62,19 +62,4 @@ public class QueryConfig {
    * <strong>query.auth-class</strong><br>The class that should be used (if any) to authenticate queries to the specified <strong>query.fhir-server-base</strong>.
    */
   private String authClass;
-
-  /**
-   * <strong>query.patient-resource-types</strong><br>The list of resource types supported by the configured EHR's FHIR API that are specific to a patient (support the 'patient' search parameter)
-   */
-  private List<String> patientResourceTypes;
-
-  /**
-   * <strong>query.other-resource-types</strong><br>The list of resource types supported by the configured EHR's FHIR API that are NOT specific to a patient. These are queried via references from patient resources.
-   */
-  private List<String> otherResourceTypes;
-
-  /**
-   * <strong>query.parallel-patients</strong><br>The number of patients to query for at a single time.
-   */
-  private int parallelPatients = 10;
 }

--- a/core/src/main/java/com/lantanagroup/link/config/query/USCoreConfig.java
+++ b/core/src/main/java/com/lantanagroup/link/config/query/USCoreConfig.java
@@ -1,0 +1,35 @@
+package com.lantanagroup.link.config.query;
+
+import com.lantanagroup.link.config.YamlPropertySourceFactory;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.validation.annotation.Validated;
+
+import java.util.List;
+
+@Getter
+@Setter
+@Configuration
+@ConfigurationProperties(prefix = "uscore")
+@Validated
+@PropertySource(value = "classpath:application.yml", factory = YamlPropertySourceFactory.class)
+public class USCoreConfig {
+
+  /**
+   * <strong>query.patient-resource-types</strong><br>The list of resource types supported by the configured EHR's FHIR API that are specific to a patient (support the 'patient' search parameter)
+   */
+  private List<String> patientResourceTypes;
+
+  /**
+   * <strong>query.other-resource-types</strong><br>The list of resource types supported by the configured EHR's FHIR API that are NOT specific to a patient. These are queried via references from patient resources.
+   */
+  private List<String> otherResourceTypes;
+
+  /**
+   * <strong>query.parallel-patients</strong><br>The number of patients to query for at a single time.
+   */
+  private int parallelPatients = 10;
+}

--- a/query/src/main/java/com/lantanagroup/link/query/uscore/PatientData.java
+++ b/query/src/main/java/com/lantanagroup/link/query/uscore/PatientData.java
@@ -5,11 +5,13 @@ import ca.uhn.fhir.rest.client.api.IGenericClient;
 import com.lantanagroup.link.FhirHelper;
 import com.lantanagroup.link.ResourceIdChanger;
 import com.lantanagroup.link.config.query.QueryConfig;
+import com.lantanagroup.link.config.query.USCoreConfig;
 import com.lantanagroup.link.query.uscore.scoop.PatientScoop;
 import org.hl7.fhir.r4.model.*;
 import org.hl7.fhir.r4.model.Bundle.BundleType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -21,16 +23,16 @@ public class PatientData {
   private final Patient patient;
   private final String patientId;
   private final IGenericClient fhirQueryServer;
-  // private final USCoreConfig usCoreConfig;
-  private final QueryConfig queryConfig;
+  private final USCoreConfig usCoreConfig;
+  // private final QueryConfig queryConfig;
   private List<String> resourceTypes;
   private List<Bundle> bundles = new ArrayList<>();
 
-  public PatientData(IGenericClient fhirQueryServer, Patient patient, QueryConfig queryConfig, List<String> resourceTypes) {
+  public PatientData(IGenericClient fhirQueryServer, Patient patient, USCoreConfig usCoreConfig, List<String> resourceTypes) {
     this.fhirQueryServer = fhirQueryServer;
     this.patient = patient;
     this.patientId = patient.getIdElement().getIdPart();
-    this.queryConfig = queryConfig;
+    this.usCoreConfig = usCoreConfig;
     this.resourceTypes = resourceTypes;
   }
 
@@ -72,10 +74,10 @@ public class PatientData {
   }
 
   private void getAdditionalResources(Bundle bundle, List<Reference> resourceReferences){
-    if (this.queryConfig.getOtherResourceTypes() != null) {
+    if (this.usCoreConfig.getOtherResourceTypes() != null) {
       for (Reference reference : resourceReferences) {
         String[] refParts = reference.getReference().split("/");
-        List<String> otherResourceTypes = this.queryConfig.getOtherResourceTypes();
+        List<String> otherResourceTypes = this.usCoreConfig.getOtherResourceTypes();
         if (otherResourceTypes.contains(refParts[0])) {
           Resource resource = (Resource) this.fhirQueryServer.read()
                   .resource(refParts[0])

--- a/query/src/main/java/com/lantanagroup/link/query/uscore/scoop/PatientScoop.java
+++ b/query/src/main/java/com/lantanagroup/link/query/uscore/scoop/PatientScoop.java
@@ -3,6 +3,7 @@ package com.lantanagroup.link.query.uscore.scoop;
 import ca.uhn.fhir.rest.client.api.IGenericClient;
 import ca.uhn.fhir.rest.server.exceptions.AuthenticationException;
 import com.lantanagroup.link.config.query.QueryConfig;
+import com.lantanagroup.link.config.query.USCoreConfig;
 import com.lantanagroup.link.model.PatientOfInterestModel;
 import com.lantanagroup.link.query.uscore.PatientData;
 import lombok.Getter;
@@ -32,6 +33,9 @@ public class PatientScoop extends Scoop {
   @Autowired
   private QueryConfig queryConfig;
 
+  @Autowired
+  private USCoreConfig usCoreConfig;
+
   public void execute(List<PatientOfInterestModel> pois, List<String> resourceTypes) throws Exception {
     if (this.fhirQueryServer == null) {
       throw new Exception("No FHIR server to query");
@@ -44,7 +48,7 @@ public class PatientScoop extends Scoop {
     if (patient == null) return null;
 
     try {
-      PatientData patientData = new PatientData(this.getFhirQueryServer(), patient, this.queryConfig, resourceTypes);
+      PatientData patientData = new PatientData(this.getFhirQueryServer(), patient, this.usCoreConfig, resourceTypes);
       patientData.loadData();
       return patientData;
     } catch (Exception e) {
@@ -98,7 +102,7 @@ public class PatientScoop extends Scoop {
     try {
       // loop through the patient ids to retrieve the patientData using each patient.
       List<Patient> patients = new ArrayList<>(patientMap.values());
-      int threshold = queryConfig.getParallelPatients();
+      int threshold = usCoreConfig.getParallelPatients();
       logger.info(String.format("Throttling patient query load to " + threshold + " at a time"));
       ForkJoinPool forkJoinPool = new ForkJoinPool(threshold);
 

--- a/query/src/test/java/com/lantanagroup/link/query/uscore/QueryTests.java
+++ b/query/src/test/java/com/lantanagroup/link/query/uscore/QueryTests.java
@@ -3,6 +3,7 @@ package com.lantanagroup.link.query.uscore;
 import ca.uhn.fhir.rest.client.api.IGenericClient;
 import ca.uhn.fhir.rest.gclient.*;
 import com.lantanagroup.link.config.query.QueryConfig;
+import com.lantanagroup.link.config.query.USCoreConfig;
 import com.lantanagroup.link.model.PatientOfInterestModel;
 import com.lantanagroup.link.model.QueryResponse;
 import com.lantanagroup.link.query.uscore.scoop.PatientScoop;
@@ -30,13 +31,14 @@ public class QueryTests {
     queries.add("Encounter");
     queries.add("MedicationRequest");
     QueryConfig queryConfig = new QueryConfig();
-    queryConfig.setPatientResourceTypes(queries);
-    queryConfig.getPatientResourceTypes();
+    USCoreConfig usCoreConfig = new USCoreConfig();
+    usCoreConfig.setPatientResourceTypes(queries);
+    usCoreConfig.getPatientResourceTypes();
     List<String> extraResources = new ArrayList<>();
     extraResources.add("Location");
     extraResources.add("Medication");
-    queryConfig.setOtherResourceTypes(extraResources);
-    queryConfig.getOtherResourceTypes();
+    usCoreConfig.setOtherResourceTypes(extraResources);
+    usCoreConfig.getOtherResourceTypes();
 
     PatientScoop patientScoop = new PatientScoop();
     patientScoop.setQueryConfig(queryConfig);

--- a/query/src/test/java/com/lantanagroup/link/query/uscore/QueryTests.java
+++ b/query/src/test/java/com/lantanagroup/link/query/uscore/QueryTests.java
@@ -41,6 +41,7 @@ public class QueryTests {
     usCoreConfig.getOtherResourceTypes();
 
     PatientScoop patientScoop = new PatientScoop();
+    patientScoop.setUsCoreConfig(usCoreConfig);
     patientScoop.setQueryConfig(queryConfig);
     patientScoop.setFhirQueryServer(fhirQueryClient);
 


### PR DESCRIPTION
Created a USCoreConfig class and moved over parallelPatients, patientResourceTypes, otherResourceTypes to it from QueryConfig and modified the classes that use these values to get them from USCoreConfig instead.