### PR TITLE
LINK-874: Transform CSV report submission in consumer and store

### DIFF
--- a/consumer/src/main/java/com/lantanagroup/link/consumer/api/JpaRestfulServer.java
+++ b/consumer/src/main/java/com/lantanagroup/link/consumer/api/JpaRestfulServer.java
@@ -92,6 +92,7 @@ public class JpaRestfulServer extends RestfulServer {
     this.registerInterceptor(new UserInterceptor(consumerConfig.getIssuer(), consumerConfig.getAuthJwksUrl()));
     this.registerInterceptor(new AuthInterceptor(consumerConfig));
 
+    reportCsvOperationProvider.initialize();
     this.registerProvider(reportCsvOperationProvider);
   }
 


### PR DESCRIPTION
Addresses a suggestion on the previous PR.  We should *preload* the THSA summary measure, rather than falling back to a Java resource if the measure isn't found.