### PR TITLE
LINK-1067: Make IP checking for JWT conditional based on configuration

### DIFF
--- a/api/src/main/java/com/lantanagroup/link/api/ApiSecurityConfig.java
+++ b/api/src/main/java/com/lantanagroup/link/api/ApiSecurityConfig.java
@@ -37,7 +37,7 @@ public class ApiSecurityConfig extends WebSecurityConfigurerAdapter {
 
   @Override
   protected void configure(HttpSecurity http) throws Exception {
-    PreAuthTokenHeaderFilter authFilter = new PreAuthTokenHeaderFilter("Authorization", linkCredentials);
+    PreAuthTokenHeaderFilter authFilter = new PreAuthTokenHeaderFilter("Authorization", linkCredentials, config);
     authFilter.setAuthenticationManager(new LinkAuthManager(config.getIssuer(), config.getAuthJwksUrl()));
     authFilter.setAuthenticationSuccessHandler(new LinkAuthenticationSuccessHandler(this.config));
     http

--- a/core/src/main/java/com/lantanagroup/link/config/api/ApiConfig.java
+++ b/core/src/main/java/com/lantanagroup/link/config/api/ApiConfig.java
@@ -79,6 +79,13 @@ public class ApiConfig {
   private String issuer;
 
   /**
+   * <strong>api.check-ip-address</strong><br>Check if the IP address in the jwt token matches the ip address of the request
+   */
+  @Getter
+  @Setter
+  private Boolean checkIpAddress = true;
+
+  /**
    * <strong>api.downloader</strong><br>The class used to download reports
    */
   @NotNull


### PR DESCRIPTION
Added check-ip-address configuration option for ApiConfig. By default, it is set to true. To disable it add check-ip-address: false in the config file.