### PR TITLE
Link 978

### DIFF
--- a/api/src/main/java/com/lantanagroup/link/api/controller/BaseController.java
+++ b/api/src/main/java/com/lantanagroup/link/api/controller/BaseController.java
@@ -4,6 +4,7 @@ import ca.uhn.fhir.context.FhirContext;
 import com.lantanagroup.link.FhirContextProvider;
 import com.lantanagroup.link.FhirDataProvider;
 import com.lantanagroup.link.config.api.ApiConfig;
+import com.lantanagroup.link.config.bundler.BundlerConfig;
 import lombok.Setter;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -16,6 +17,10 @@ public class BaseController {
   @Setter
   @Autowired
   protected ApiConfig config;
+
+  @Setter
+  @Autowired
+  protected BundlerConfig bundlerConfig;
 
   @Autowired
   @Setter

--- a/api/src/main/java/com/lantanagroup/link/api/controller/ReportController.java
+++ b/api/src/main/java/com/lantanagroup/link/api/controller/ReportController.java
@@ -316,8 +316,8 @@ public class ReportController extends BaseController {
     documentReference = FhirHelper.incrementMajorVersion(documentReference);
 
     sender.send(report, documentReference, request, authentication, this.getFhirDataProvider(),
-            this.config.getSendWholeBundle() != null ? this.config.getSendWholeBundle() : true,
-            this.config.isRemoveGeneratedObservations());
+            this.bundlerConfig.getSendWholeBundle() != null ? this.bundlerConfig.getSendWholeBundle() : true,
+            this.bundlerConfig.isRemoveGeneratedObservations());
 
     // Now that we've submitted (successfully), update the doc ref with the status and date
     this.getFhirDataProvider().updateResource(documentReference);
@@ -392,7 +392,7 @@ public class ReportController extends BaseController {
     Constructor<?> downloaderCtor = downloaderClass.getConstructor();
     downloader = (IReportDownloader) downloaderCtor.newInstance();
 
-    downloader.download(reportId, this.getFhirDataProvider(), response, this.ctx, this.config);
+    downloader.download(reportId, this.getFhirDataProvider(), response, this.ctx, this.bundlerConfig);
 
     this.getFhirDataProvider().audit(request, ((LinkCredentials) authentication.getPrincipal()).getJwt(), FhirHelper.AuditEventTypes.Export, "Successfully Exported Report for Download");
   }

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -44,6 +44,9 @@ api:
   measure-evaluation-threads: 10
 thsa:
   dataMeasureReportId: inventorydata
+bundler:
+  send-whole-bundle: false
+  remove-generated-observations: false
 query:
   require-https: true
   query-class: com.lantanagroup.link.query.uscore.Query

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -45,8 +45,8 @@ api:
 thsa:
   dataMeasureReportId: inventorydata
 bundler:
-  send-whole-bundle: false
-  remove-generated-observations: false
+  send-whole-bundle: true
+  remove-generated-observations: true
 query:
   require-https: true
   query-class: com.lantanagroup.link.query.uscore.Query

--- a/core/src/main/java/com/lantanagroup/link/IReportDownloader.java
+++ b/core/src/main/java/com/lantanagroup/link/IReportDownloader.java
@@ -2,11 +2,12 @@ package com.lantanagroup.link;
 
 import ca.uhn.fhir.context.FhirContext;
 import com.lantanagroup.link.config.api.ApiConfig;
+import com.lantanagroup.link.config.bundler.BundlerConfig;
 
 import javax.servlet.http.HttpServletResponse;
 import javax.xml.transform.TransformerException;
 import java.io.IOException;
 
 public interface IReportDownloader {
-  void download(String reportId, FhirDataProvider fhirDataProvider, HttpServletResponse response, FhirContext ctx, ApiConfig config) throws IOException, TransformerException;
+  void download(String reportId, FhirDataProvider fhirDataProvider, HttpServletResponse response, FhirContext ctx, BundlerConfig config) throws IOException, TransformerException;
 }

--- a/core/src/main/java/com/lantanagroup/link/config/api/ApiConfig.java
+++ b/core/src/main/java/com/lantanagroup/link/config/api/ApiConfig.java
@@ -95,15 +95,6 @@ public class ApiConfig {
   @NotNull
   private String sender;
 
-  /**
-   * <strong>api.send-whole-bundle</strong><br>Boolean used to determine if the full Bundle is sent or just the MeasureReport. True to send full bundle and false to send just the MeasureReport
-   */
-  private Boolean sendWholeBundle;
-
-  /**
-   * <strong>api.remove-generated-observations</strong><br>Whether to remove contained evaluated resources from patient measure reports
-   */
-  private boolean removeGeneratedObservations = true;
 
   /**
    * <strong>api.patient-id-resolver</strong><br>The class used to determine the list of patient ids that should be queried for

--- a/core/src/main/java/com/lantanagroup/link/config/bundler/BundlerConfig.java
+++ b/core/src/main/java/com/lantanagroup/link/config/bundler/BundlerConfig.java
@@ -1,0 +1,27 @@
+package com.lantanagroup.link.config.bundler;
+
+import com.lantanagroup.link.config.YamlPropertySourceFactory;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.validation.annotation.Validated;
+
+@Getter
+@Setter
+@Configuration
+@ConfigurationProperties(prefix = "bundler")
+@Validated
+@PropertySource(value = "classpath:application.yml", factory = YamlPropertySourceFactory.class)
+public class BundlerConfig {
+  /**
+   * <strong>api.send-whole-bundle</strong><br>Boolean used to determine if the full Bundle is sent or just the MeasureReport. True to send full bundle and false to send just the MeasureReport
+   */
+  private Boolean sendWholeBundle;
+
+  /**
+   * <strong>api.remove-generated-observations</strong><br>Whether to remove contained evaluated resources from patient measure reports
+   */
+  private boolean removeGeneratedObservations = true;
+}

--- a/nhsn/src/main/java/com/lantanagroup/link/nhsn/MeasureReportDownloader.java
+++ b/nhsn/src/main/java/com/lantanagroup/link/nhsn/MeasureReportDownloader.java
@@ -3,6 +3,7 @@ package com.lantanagroup.link.nhsn;
 import ca.uhn.fhir.context.FhirContext;
 import com.lantanagroup.link.*;
 import com.lantanagroup.link.config.api.ApiConfig;
+import com.lantanagroup.link.config.bundler.BundlerConfig;
 import org.apache.commons.io.IOUtils;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.DocumentReference;
@@ -22,7 +23,7 @@ public class MeasureReportDownloader implements IReportDownloader {
   protected static final Logger logger = LoggerFactory.getLogger(MeasureReportDownloader.class);
 
   @Override
-  public void download(String reportId, FhirDataProvider fhirDataProvider, HttpServletResponse response, FhirContext ctx, ApiConfig config) throws IOException, TransformerException {
+  public void download(String reportId, FhirDataProvider fhirDataProvider, HttpServletResponse response, FhirContext ctx, BundlerConfig config) throws IOException, TransformerException {
 
     DocumentReference docRefBundle = fhirDataProvider.findDocRefForReport(reportId);
 


### PR DESCRIPTION
Created a BundlerConfig class and moved the sendWholeBundle and removeGeneratedObservations variables from ApiConfig to it. I was able to successfully generate a report and submit it with these changes.