### PR TITLE
Practitioner lookup fails if name/email missing

### DIFF
--- a/api/src/main/java/com/lantanagroup/link/api/auth/LinkAuthenticationSuccessHandler.java
+++ b/api/src/main/java/com/lantanagroup/link/api/auth/LinkAuthenticationSuccessHandler.java
@@ -16,7 +16,6 @@ import org.springframework.security.web.authentication.AuthenticationSuccessHand
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import java.util.List;
 
 public class LinkAuthenticationSuccessHandler implements AuthenticationSuccessHandler {
   private static final Logger logger = LoggerFactory.getLogger(LinkAuthenticationSuccessHandler.class);
@@ -60,34 +59,25 @@ public class LinkAuthenticationSuccessHandler implements AuthenticationSuccessHa
     }
   }
 
-  private String checkFamily (Practitioner practitioner) {
-    return !practitioner.getName().isEmpty()?
-            (StringUtils.isNotBlank(practitioner.getName().get(0).getFamily())?
-                    practitioner.getName().get(0).getFamily():""):"";
+  private String getFamilyName(Practitioner practitioner) {
+    return practitioner.getNameFirstRep().getFamily();
   }
 
-  private String checkGiven(Practitioner practitioner) {
-    return !practitioner.getName().isEmpty()?
-            (!practitioner.getName().get(0).getGiven().isEmpty()?
-                    (StringUtils.isNotBlank(practitioner.getName().get(0).getGiven().get(0).toString())?
-                            practitioner.getName().get(0).getGiven().get(0).toString():""):""):"";
+  private String getGivenName(Practitioner practitioner) {
+    return practitioner.getNameFirstRep().getGivenAsSingleString();
   }
 
-  private String checkEmailValue(Practitioner practitioner) {
-    return !practitioner.getTelecomFirstRep().isEmpty()?
-              (StringUtils.isNotBlank(practitioner.getTelecomFirstRep().getValue())?
-              practitioner.getTelecomFirstRep().getValue():""):"";
-  }
-
-  private ContactPoint.ContactPointSystem checkEmailSystem(Practitioner practitioner) {
-    return !practitioner.getTelecomFirstRep().isEmpty()?
-              practitioner.getTelecomFirstRep().getSystem():ContactPoint.ContactPointSystem.NULL;
+  private String getEmailAddress(Practitioner practitioner) {
+    return practitioner.getTelecom().stream()
+            .filter(telecom -> telecom.getSystem() == ContactPoint.ContactPointSystem.EMAIL)
+            .map(ContactPoint::getValue)
+            .findFirst()
+            .orElse(null);
   }
 
   private boolean isSamePractitioner(Practitioner practitioner1, Practitioner practitioner2) {
-   return (StringUtils.equals(checkFamily(practitioner1),checkFamily(practitioner2)) ||
-            StringUtils.equals(checkGiven(practitioner1),checkGiven(practitioner2)) ||
-            checkEmailSystem(practitioner1) == checkEmailSystem(practitioner2) ||
-            StringUtils.equals(checkEmailValue(practitioner1),checkEmailValue(practitioner2)));
+    return StringUtils.equals(getFamilyName(practitioner1), getFamilyName(practitioner2))
+            && StringUtils.equals(getGivenName(practitioner1), getGivenName(practitioner2))
+            && StringUtils.equals(getEmailAddress(practitioner1), getEmailAddress(practitioner2));
   }
 }

--- a/api/src/main/java/com/lantanagroup/link/api/auth/LinkAuthenticationSuccessHandler.java
+++ b/api/src/main/java/com/lantanagroup/link/api/auth/LinkAuthenticationSuccessHandler.java
@@ -85,13 +85,9 @@ public class LinkAuthenticationSuccessHandler implements AuthenticationSuccessHa
   }
 
   private boolean isSamePractitioner(Practitioner practitioner1, Practitioner practitioner2) {
-    boolean same = true;
-    if (!StringUtils.equals(checkFamily(practitioner1),checkFamily(practitioner2)) ||
-            !StringUtils.equals(checkGiven(practitioner1),checkGiven(practitioner2)) ||
-            checkEmailSystem(practitioner1) != checkEmailSystem(practitioner2) ||
-            !StringUtils.equals(checkEmailValue(practitioner1),checkEmailValue(practitioner2))) {
-      same = false;
-    }
-    return same;
+   return (StringUtils.equals(checkFamily(practitioner1),checkFamily(practitioner2)) ||
+            StringUtils.equals(checkGiven(practitioner1),checkGiven(practitioner2)) ||
+            checkEmailSystem(practitioner1) == checkEmailSystem(practitioner2) ||
+            StringUtils.equals(checkEmailValue(practitioner1),checkEmailValue(practitioner2)));
   }
 }

--- a/api/src/main/java/com/lantanagroup/link/api/auth/LinkAuthenticationSuccessHandler.java
+++ b/api/src/main/java/com/lantanagroup/link/api/auth/LinkAuthenticationSuccessHandler.java
@@ -4,6 +4,7 @@ import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
 import com.lantanagroup.link.FhirDataProvider;
 import com.lantanagroup.link.auth.LinkCredentials;
 import com.lantanagroup.link.config.api.ApiConfig;
+import org.apache.commons.lang3.StringUtils;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.Practitioner;
 import org.hl7.fhir.r4.model.Resource;
@@ -59,14 +60,22 @@ public class LinkAuthenticationSuccessHandler implements AuthenticationSuccessHa
 
   private boolean isSamePractitioner(Practitioner practitioner1, Practitioner practitioner2) {
     boolean same = true;
-    String familyNamePractitioner1 = practitioner1.getName().get(0).getFamily();
-    String familyNamePractitioner2 = practitioner2.getName().get(0).getFamily();
-    String givenNamePractitioner1 = practitioner1.getName().get(0).getGiven().get(0).toString();
-    String givenNamePractitioner2 = practitioner2.getName().get(0).getGiven().get(0).toString();
-    String email1Value = practitioner1.getTelecomFirstRep().getValue();
-    String email2Value = practitioner2.getTelecomFirstRep().getValue();
-    String email1System = practitioner1.getTelecomFirstRep().getSystem().name();
-    String email2System = practitioner2.getTelecomFirstRep().getSystem().name();
+    String familyNamePractitioner1 = StringUtils.isNotBlank(practitioner1.getName().get(0).getFamily())?
+            practitioner1.getName().get(0).getFamily():"";
+    String familyNamePractitioner2 = StringUtils.isNotBlank(practitioner2.getName().get(0).getFamily())?
+            practitioner2.getName().get(0).getFamily():"";
+    String givenNamePractitioner1 = StringUtils.isNotBlank(practitioner1.getName().get(0).getGiven().get(0).toString())?
+            practitioner1.getName().get(0).getGiven().get(0).toString():"";
+    String givenNamePractitioner2 = StringUtils.isNotBlank(practitioner2.getName().get(0).getGiven().get(0).toString())?
+            practitioner2.getName().get(0).getGiven().get(0).toString():"";
+    String email1Value = StringUtils.isNotBlank(practitioner1.getTelecomFirstRep().getValue())?
+            practitioner1.getTelecomFirstRep().getValue():"";
+    String email2Value = StringUtils.isNotBlank(practitioner2.getTelecomFirstRep().getValue())?
+            practitioner2.getTelecomFirstRep().getValue():"";
+    String email1System = StringUtils.isNotBlank(practitioner1.getTelecomFirstRep().getSystem().name())?
+            practitioner1.getTelecomFirstRep().getSystem().name():"";
+    String email2System = StringUtils.isNotBlank(practitioner2.getTelecomFirstRep().getSystem().name())?
+            practitioner2.getTelecomFirstRep().getSystem().name():"";
     if (!familyNamePractitioner1.equals(familyNamePractitioner2) || !givenNamePractitioner1.equals(givenNamePractitioner2) ||
             !email1System.equals(email2System) || !email1Value.equals(email2Value)) {
       same = false;


### PR DESCRIPTION
Added null checks to isSamePractitioner in LinkAuthenticationSuccessHandler when comparing the practitioner dynamically generated from the JWT to a previously stored practitioner for the practitioner's given name, family name, and email.