### PR TITLE
NHSNLink - Create a config property under api that represents the tenant ID for the facility

### DIFF
--- a/core/src/main/java/com/lantanagroup/link/config/api/ApiConfig.java
+++ b/core/src/main/java/com/lantanagroup/link/config/api/ApiConfig.java
@@ -27,6 +27,12 @@ public class ApiConfig {
   private Boolean validateFhirServer;
 
   /**
+   *<strong>api.tenant-id<strong/><br>Tenant ID for the facility
+   */
+  @Getter
+  private String tenantID;
+
+  /**
    * <strong>api.public-address</strong><br>The public endpoint address for the API (i.e. https://dev.nhsnlink.org/api)
    */
   @Getter


### PR DESCRIPTION
Added tenantID to ApiConfig and application-dev.yml