### PR TITLE
Making query params more flexible via config

### DIFF
--- a/core/src/main/java/com/lantanagroup/link/config/query/USCoreQueryParametersResourceConfig.java
+++ b/core/src/main/java/com/lantanagroup/link/config/query/USCoreQueryParametersResourceConfig.java
@@ -1,12 +1,16 @@
 package com.lantanagroup.link.config.query;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.util.List;
 
 @Getter
 @Setter
+@AllArgsConstructor
+@NoArgsConstructor
 public class USCoreQueryParametersResourceConfig {
   private String resourceType;
   private List<USCoreQueryParametersResourceParameterConfig> parameters;

--- a/core/src/main/java/com/lantanagroup/link/config/query/USCoreQueryParametersResourceParameterConfig.java
+++ b/core/src/main/java/com/lantanagroup/link/config/query/USCoreQueryParametersResourceParameterConfig.java
@@ -1,12 +1,17 @@
 package com.lantanagroup.link.config.query;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.util.List;
 
 @Getter
 @Setter
+@AllArgsConstructor
+@NoArgsConstructor
 public class USCoreQueryParametersResourceParameterConfig {
   private String name;
+  private Boolean singleParam;
   private List<String> values;
 }

--- a/nhsn/src/main/java/com/lantanagroup/link/nhsn/PatientDataResourceFilter.java
+++ b/nhsn/src/main/java/com/lantanagroup/link/nhsn/PatientDataResourceFilter.java
@@ -85,6 +85,14 @@ public class PatientDataResourceFilter implements IReportGenerationDataEvent {
           }
         }
         break;
+      case Specimen:
+        Specimen specimen = (Specimen) resource;
+
+        if (specimen.getReceivedTime() != null) {
+          if (!isWithin(specimen.getReceivedTime().toInstant(), start, end)) {
+            return true;
+          }
+        }
     }
 
     return false;

--- a/query/src/main/java/com/lantanagroup/link/query/uscore/PatientData.java
+++ b/query/src/main/java/com/lantanagroup/link/query/uscore/PatientData.java
@@ -14,8 +14,8 @@ import org.hl7.fhir.r4.model.Bundle.BundleType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.time.Instant;
-import java.time.format.DateTimeFormatter;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -31,7 +31,6 @@ public class PatientData {
   private List<String> resourceTypes;
   private List<Bundle> bundles = new ArrayList<>();
 
-
   public PatientData(IGenericClient fhirQueryServer, ReportCriteria criteria, Patient patient, USCoreConfig usCoreConfig, List<String> resourceTypes) {
     this.fhirQueryServer = fhirQueryServer;
     this.criteria = criteria;
@@ -39,6 +38,64 @@ public class PatientData {
     this.patientId = patient.getIdElement().getIdPart();
     this.usCoreConfig = usCoreConfig;
     this.resourceTypes = resourceTypes;
+  }
+
+  /**
+   * Only return the ISO time precise to the second
+   *
+   * @param value
+   * @return
+   */
+  public static String getDateTimeString(String value) {
+    if (value != null && value.length() > 19) {
+      return value.substring(0, 19);
+    }
+    return value;
+  }
+
+  public static String getQueryParamValue(String value, ReportCriteria criteria) {
+    String ret = value
+            //.replace("${periodLookbackStart}", )
+            .replace("${periodStart}", getDateTimeString(criteria.getPeriodStart()))
+            .replace("${periodEnd}", getDateTimeString(criteria.getPeriodEnd()));
+    return URLEncoder.encode(ret, StandardCharsets.UTF_8);
+  }
+
+  public static String getQuery(USCoreConfig usCoreConfig, List<String> measureIds, ReportCriteria criteria, String resourceType, String patientId) {
+    String finalResourceType = resourceType;
+    ArrayList<String> params = new ArrayList<>(List.of("patient=Patient/" + URLEncoder.encode(patientId, StandardCharsets.UTF_8)));
+    HashMap<String, List<USCoreQueryParametersResourceConfig>> queryParameters = usCoreConfig.getQueryParameters();
+
+    //check if queryParameters exist in config, if not just load patient without observations
+    for (String measureId : measureIds) {
+      if (queryParameters != null && !queryParameters.isEmpty()) {
+        if (usCoreConfig.getQueryParameters() != null && usCoreConfig.getQueryParameters().containsKey(measureId)) {
+
+          List<USCoreQueryParametersResourceConfig> resourceQueryParams =
+                  usCoreConfig.getQueryParameters()
+                          .get(measureId)
+                          .stream()
+                          .filter(queryParams -> queryParams.getResourceType().equals(finalResourceType))
+                          .collect(Collectors.toList());
+
+          for (USCoreQueryParametersResourceConfig resourceQueryParam : resourceQueryParams) {
+            for (USCoreQueryParametersResourceParameterConfig param : resourceQueryParam.getParameters()) {
+              if (param.getSingleParam() != null && param.getSingleParam() == true) {
+                List<String> values = param.getValues().stream().map(v -> getQueryParamValue(v, criteria)).collect(Collectors.toList());
+                String paramValue = String.join(",", values);
+                params.add(param.getName() + "=" + paramValue);
+              } else {
+                for (String paramValue : param.getValues()) {
+                  params.add(param.getName() + "=" + getQueryParamValue(paramValue, criteria));
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    return resourceType += "?" + String.join("&", params);
   }
 
   public void loadData(List<String> measureIds) {
@@ -49,53 +106,8 @@ public class PatientData {
 
     //Loop through resource types specified. If observation, use config to add individual category queries
     Set<String> queryString = new HashSet<>();
-    for (String resource: this.resourceTypes) {
-
-      String dateParameters;
-      if (usCoreConfig.getLookbackPeriod() != null) {
-        Instant start = Instant.parse(criteria.getPeriodStart()).minus(usCoreConfig.getLookbackPeriod());
-        Instant end = Instant.parse(criteria.getPeriodEnd());
-        DateTimeFormatter formatter = DateTimeFormatter.ISO_INSTANT;
-        dateParameters = String.format("&date=ge%s&date=le%s", formatter.format(start), formatter.format(end));
-      } else {
-        dateParameters = "";
-      }
-
-      if(resource.equals("Observation")) {
-
-        HashMap<String, List<USCoreQueryParametersResourceConfig>> queryParameters = this.usCoreConfig.getQueryParameters();
-
-        //check if queryParameters exist in config, if not just load patient without observations
-        for (String measureId : measureIds) {
-          if (queryParameters != null && !queryParameters.isEmpty()) {
-            if (this.usCoreConfig.getQueryParameters() != null && this.usCoreConfig.getQueryParameters().containsKey(measureId)) {
-              //this was written in a way that if the resource equals check was removed, it would work for other resource types
-              this.usCoreConfig.getQueryParameters().get(measureId).stream().forEach(queryParams -> {
-                // TODO: Verify that we're dealing with the correct resource type
-                //       I.e., the resource type of queryParams must be equal to resource (the outer loop variable)
-                //       Could make that check here (within the forEach) or in a filter before the forEach
-                for (USCoreQueryParametersResourceParameterConfig param : queryParams.getParameters()) {
-                  for (String paramValue : param.getValues()) {
-                    // TODO: Use Apache's URLEncodedUtils or similar to encode query string components
-                    queryString.add(queryParams.getResourceType() + "?" + param.getName() + "=" + paramValue + "&patient=Patient/" + this.patientId
-                            + (usCoreConfig.getLookbackResourceTypes().contains(resource) ? dateParameters : ""));
-                  }
-                }
-              });
-            }
-          }
-          else {
-            logger.warn("No observations found in US Core Config for {}, loading patient data without observations.", Helper.encodeLogging(measureId));
-            // TODO: Fall back to a query with the patient parameter only?
-            //       I.e., uncomment the following line and remove the category parameter?
-            //queryString.add(resource + "?category=laboratory&?patient=Patient/" + this.patientId);
-          }
-        }
-
-      }
-      else {
-        queryString.add(resource + "?patient=Patient/" + this.patientId + (usCoreConfig.getLookbackResourceTypes().contains(resource) ? dateParameters : ""));
-      }
+    for (String resource : this.resourceTypes) {
+      queryString.add(getQuery(this.usCoreConfig, measureIds, criteria, resource, patientId));
     }
 
     if(!queryString.isEmpty()) {

--- a/query/src/test/java/com/lantanagroup/link/query/uscore/PatientDataTests.java
+++ b/query/src/test/java/com/lantanagroup/link/query/uscore/PatientDataTests.java
@@ -15,7 +15,6 @@ public class PatientDataTests {
   @Test
   public void getQueryTest_ObservationWithCategoryAndDate() {
     USCoreConfig config = new USCoreConfig();
-    config.setLookbackPeriod(Period.ofDays(1));
     config.setQueryParameters(new HashMap<>());
     config.getQueryParameters().put("measure1",
             List.of(new USCoreQueryParametersResourceConfig("Observation",
@@ -30,9 +29,37 @@ public class PatientDataTests {
   }
 
   @Test
+  public void getQueryTest_ObservationWithLookBackDate() {
+    USCoreConfig config = new USCoreConfig();
+    config.setLookbackPeriod(Period.ofDays(14));
+    config.setQueryParameters(new HashMap<>());
+    config.getQueryParameters().put("measure1",
+            List.of(new USCoreQueryParametersResourceConfig("Observation",
+                    List.of(new USCoreQueryParametersResourceParameterConfig("date", false, List.of("ge${lookBackStart}", "le${periodEnd}"))))));
+
+    ReportCriteria criteria = new ReportCriteria(List.of("measure1"), "2022-01-01T00:00:00.000+00:00", "2022-01-31T23:59:59.000+00:00");
+
+    String queryString = PatientData.getQuery(config, List.of("measure1"), criteria, "Observation", "patient1");
+    Assert.assertEquals("Observation?patient=Patient/patient1&date=ge2021-12-18T00%3A00%3A00&date=le2022-01-31T23%3A59%3A59", queryString);
+  }
+
+  @Test
+  public void getQueryTest_ObservationWithLookBackDate_NoLookBackConfig() {
+    USCoreConfig config = new USCoreConfig();
+    config.setQueryParameters(new HashMap<>());
+    config.getQueryParameters().put("measure1",
+            List.of(new USCoreQueryParametersResourceConfig("Observation",
+                    List.of(new USCoreQueryParametersResourceParameterConfig("date", false, List.of("ge${lookBackStart}", "le${periodEnd}"))))));
+
+    ReportCriteria criteria = new ReportCriteria(List.of("measure1"), "2022-01-01T00:00:00.000+00:00", "2022-01-31T23:59:59.000+00:00");
+
+    String queryString = PatientData.getQuery(config, List.of("measure1"), criteria, "Observation", "patient1");
+    Assert.assertEquals("Observation?patient=Patient/patient1&date=ge2022-01-01T00%3A00%3A00&date=le2022-01-31T23%3A59%3A59", queryString);
+  }
+
+  @Test
   public void getQueryTest_MedicationRequest() {
     USCoreConfig config = new USCoreConfig();
-    config.setLookbackPeriod(Period.ofDays(1));
     config.setQueryParameters(new HashMap<>());
     config.getQueryParameters().put("measure1",
             List.of(new USCoreQueryParametersResourceConfig("Observation",
@@ -47,7 +74,6 @@ public class PatientDataTests {
   @Test
   public void getQueryTest_EncounterWithDate() {
     USCoreConfig config = new USCoreConfig();
-    config.setLookbackPeriod(Period.ofDays(1));
     config.setQueryParameters(new HashMap<>());
     config.getQueryParameters().put("measure1",
             List.of(new USCoreQueryParametersResourceConfig("Encounter",
@@ -62,7 +88,6 @@ public class PatientDataTests {
   @Test
   public void getQueryTest_Condition_NoConfig() {
     USCoreConfig config = new USCoreConfig();
-    config.setLookbackPeriod(Period.ofDays(1));
     config.setQueryParameters(new HashMap<>());
     config.getQueryParameters().put("measure1",
             List.of(new USCoreQueryParametersResourceConfig("Encounter",

--- a/query/src/test/java/com/lantanagroup/link/query/uscore/PatientDataTests.java
+++ b/query/src/test/java/com/lantanagroup/link/query/uscore/PatientDataTests.java
@@ -1,0 +1,76 @@
+package com.lantanagroup.link.query.uscore;
+
+import com.lantanagroup.link.config.query.USCoreConfig;
+import com.lantanagroup.link.config.query.USCoreQueryParametersResourceConfig;
+import com.lantanagroup.link.config.query.USCoreQueryParametersResourceParameterConfig;
+import com.lantanagroup.link.model.ReportCriteria;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.time.Period;
+import java.util.HashMap;
+import java.util.List;
+
+public class PatientDataTests {
+  @Test
+  public void getQueryTest_ObservationWithCategoryAndDate() {
+    USCoreConfig config = new USCoreConfig();
+    config.setLookbackPeriod(Period.ofDays(1));
+    config.setQueryParameters(new HashMap<>());
+    config.getQueryParameters().put("measure1",
+            List.of(new USCoreQueryParametersResourceConfig("Observation",
+                    List.of(
+                            new USCoreQueryParametersResourceParameterConfig("category", true, List.of("labs", "vital-signs")),
+                            new USCoreQueryParametersResourceParameterConfig("date", false, List.of("ge${periodStart}", "le${periodEnd}"))))));
+
+    ReportCriteria criteria = new ReportCriteria(List.of("measure1"), "2022-01-01T00:00:00.000+00:00", "2022-01-31T23:59:59.000+00:00");
+
+    String queryString = PatientData.getQuery(config, List.of("measure1"), criteria, "Observation", "patient1");
+    Assert.assertEquals("Observation?patient=Patient/patient1&category=labs,vital-signs&date=ge2022-01-01T00%3A00%3A00&date=le2022-01-31T23%3A59%3A59", queryString);
+  }
+
+  @Test
+  public void getQueryTest_MedicationRequest() {
+    USCoreConfig config = new USCoreConfig();
+    config.setLookbackPeriod(Period.ofDays(1));
+    config.setQueryParameters(new HashMap<>());
+    config.getQueryParameters().put("measure1",
+            List.of(new USCoreQueryParametersResourceConfig("Observation",
+                    List.of(new USCoreQueryParametersResourceParameterConfig("category", true, List.of("labs"))))));
+
+    ReportCriteria criteria = new ReportCriteria(List.of("measure1"), "2022-01-01T00:00:00.000+00:00", "2022-01-31T23:59:59.000+00:00");
+
+    String queryString = PatientData.getQuery(config, List.of("measure1"), criteria, "MedicationRequest", "patient1");
+    Assert.assertEquals("MedicationRequest?patient=Patient/patient1", queryString);
+  }
+
+  @Test
+  public void getQueryTest_EncounterWithDate() {
+    USCoreConfig config = new USCoreConfig();
+    config.setLookbackPeriod(Period.ofDays(1));
+    config.setQueryParameters(new HashMap<>());
+    config.getQueryParameters().put("measure1",
+            List.of(new USCoreQueryParametersResourceConfig("Encounter",
+                    List.of(new USCoreQueryParametersResourceParameterConfig("date", false, List.of("ge${periodStart}", "le${periodEnd}"))))));
+
+    ReportCriteria criteria = new ReportCriteria(List.of("measure1"), "2022-01-01T00:00:00.000+00:00", "2022-01-31T23:59:59.000+00:00");
+
+    String queryString = PatientData.getQuery(config, List.of("measure1"), criteria, "Encounter", "patient1");
+    Assert.assertEquals("Encounter?patient=Patient/patient1&date=ge2022-01-01T00%3A00%3A00&date=le2022-01-31T23%3A59%3A59", queryString);
+  }
+
+  @Test
+  public void getQueryTest_Condition_NoConfig() {
+    USCoreConfig config = new USCoreConfig();
+    config.setLookbackPeriod(Period.ofDays(1));
+    config.setQueryParameters(new HashMap<>());
+    config.getQueryParameters().put("measure1",
+            List.of(new USCoreQueryParametersResourceConfig("Encounter",
+                    List.of(new USCoreQueryParametersResourceParameterConfig("date", false, List.of("ge${periodStart}", "le${periodEnd}"))))));
+
+    ReportCriteria criteria = new ReportCriteria(List.of("measure1"), "2022-01-01T00:00:00.000+00:00", "2022-01-31T23:59:59.000+00:00");
+
+    String queryString = PatientData.getQuery(config, List.of("measure1"), criteria, "Condition", "patient1");
+    Assert.assertEquals("Condition?patient=Patient/patient1", queryString);
+  }
+}


### PR DESCRIPTION
- config query params can apply to more resources than just Observation
- can indicate in config if a param with multiple values should be treated as a single comma-separated query param or separate query params
- can create variable substitutions in the param values for `${periodStart}` and `${periodEnd}` (may expand this out further in future)