### PR TITLE
Search for encounters first to support ${encounter} filter in queries

### DIFF
--- a/query/src/test/java/com/lantanagroup/link/query/uscore/PatientDataTests.java
+++ b/query/src/test/java/com/lantanagroup/link/query/uscore/PatientDataTests.java
@@ -4,6 +4,7 @@ import com.lantanagroup.link.config.query.USCoreConfig;
 import com.lantanagroup.link.config.query.USCoreQueryParametersResourceConfig;
 import com.lantanagroup.link.config.query.USCoreQueryParametersResourceParameterConfig;
 import com.lantanagroup.link.model.ReportCriteria;
+import org.hl7.fhir.r4.model.Patient;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -23,9 +24,11 @@ public class PatientDataTests {
                             new USCoreQueryParametersResourceParameterConfig("date", false, List.of("ge${periodStart}", "le${periodEnd}"))))));
 
     ReportCriteria criteria = new ReportCriteria(List.of("measure1"), "2022-01-01T00:00:00.000+00:00", "2022-01-31T23:59:59.000+00:00");
+    PatientData patientData = new PatientData(null, criteria, new Patient(), config, List.of("Patient", "Encounter", "MedicationRequest"));
 
-    String queryString = PatientData.getQuery(config, List.of("measure1"), criteria, "Observation", "patient1");
-    Assert.assertEquals("Observation?patient=Patient/patient1&category=labs,vital-signs&date=ge2022-01-01T00%3A00%3A00&date=le2022-01-31T23%3A59%3A59", queryString);
+    List<String> queryStrings = patientData.getQuery(List.of("measure1"), "Observation", "patient1");
+    Assert.assertEquals(1, queryStrings.size());
+    Assert.assertEquals("Observation?patient=Patient/patient1&category=labs,vital-signs&date=ge2022-01-01T00%3A00%3A00&date=le2022-01-31T23%3A59%3A59", queryStrings.get(0));
   }
 
   @Test
@@ -38,9 +41,11 @@ public class PatientDataTests {
                     List.of(new USCoreQueryParametersResourceParameterConfig("date", false, List.of("ge${lookBackStart}", "le${periodEnd}"))))));
 
     ReportCriteria criteria = new ReportCriteria(List.of("measure1"), "2022-01-01T00:00:00.000+00:00", "2022-01-31T23:59:59.000+00:00");
+    PatientData patientData = new PatientData(null, criteria, new Patient(), config, List.of("Patient", "Encounter", "MedicationRequest"));
 
-    String queryString = PatientData.getQuery(config, List.of("measure1"), criteria, "Observation", "patient1");
-    Assert.assertEquals("Observation?patient=Patient/patient1&date=ge2021-12-18T00%3A00%3A00&date=le2022-01-31T23%3A59%3A59", queryString);
+    List<String> queryStrings = patientData.getQuery(List.of("measure1"), "Observation", "patient1");
+    Assert.assertEquals(1, queryStrings.size());
+    Assert.assertEquals("Observation?patient=Patient/patient1&date=ge2021-12-18T00%3A00%3A00&date=le2022-01-31T23%3A59%3A59", queryStrings.get(0));
   }
 
   @Test
@@ -52,9 +57,11 @@ public class PatientDataTests {
                     List.of(new USCoreQueryParametersResourceParameterConfig("date", false, List.of("ge${lookBackStart}", "le${periodEnd}"))))));
 
     ReportCriteria criteria = new ReportCriteria(List.of("measure1"), "2022-01-01T00:00:00.000+00:00", "2022-01-31T23:59:59.000+00:00");
+    PatientData patientData = new PatientData(null, criteria, new Patient(), config, List.of("Patient", "Encounter", "MedicationRequest"));
 
-    String queryString = PatientData.getQuery(config, List.of("measure1"), criteria, "Observation", "patient1");
-    Assert.assertEquals("Observation?patient=Patient/patient1&date=ge2022-01-01T00%3A00%3A00&date=le2022-01-31T23%3A59%3A59", queryString);
+    List<String> queryStrings = patientData.getQuery(List.of("measure1"), "Observation", "patient1");
+    Assert.assertEquals(1, queryStrings.size());
+    Assert.assertEquals("Observation?patient=Patient/patient1&date=ge2022-01-01T00%3A00%3A00&date=le2022-01-31T23%3A59%3A59", queryStrings.get(0));
   }
 
   @Test
@@ -66,9 +73,11 @@ public class PatientDataTests {
                     List.of(new USCoreQueryParametersResourceParameterConfig("category", true, List.of("labs"))))));
 
     ReportCriteria criteria = new ReportCriteria(List.of("measure1"), "2022-01-01T00:00:00.000+00:00", "2022-01-31T23:59:59.000+00:00");
+    PatientData patientData = new PatientData(null, criteria, new Patient(), config, List.of("Patient", "Encounter", "MedicationRequest"));
 
-    String queryString = PatientData.getQuery(config, List.of("measure1"), criteria, "MedicationRequest", "patient1");
-    Assert.assertEquals("MedicationRequest?patient=Patient/patient1", queryString);
+    List<String> queryStrings = patientData.getQuery(List.of("measure1"), "MedicationRequest", "patient1");
+    Assert.assertEquals(1, queryStrings.size());
+    Assert.assertEquals("MedicationRequest?patient=Patient/patient1", queryStrings.get(0));
   }
 
   @Test
@@ -80,9 +89,11 @@ public class PatientDataTests {
                     List.of(new USCoreQueryParametersResourceParameterConfig("date", false, List.of("ge${periodStart}", "le${periodEnd}"))))));
 
     ReportCriteria criteria = new ReportCriteria(List.of("measure1"), "2022-01-01T00:00:00.000+00:00", "2022-01-31T23:59:59.000+00:00");
+    PatientData patientData = new PatientData(null, criteria, new Patient(), config, List.of("Patient", "Encounter", "MedicationRequest"));
 
-    String queryString = PatientData.getQuery(config, List.of("measure1"), criteria, "Encounter", "patient1");
-    Assert.assertEquals("Encounter?patient=Patient/patient1&date=ge2022-01-01T00%3A00%3A00&date=le2022-01-31T23%3A59%3A59", queryString);
+    List<String> queryStrings = patientData.getQuery(List.of("measure1"), "Encounter", "patient1");
+    Assert.assertEquals(1, queryStrings.size());
+    Assert.assertEquals("Encounter?patient=Patient/patient1&date=ge2022-01-01T00%3A00%3A00&date=le2022-01-31T23%3A59%3A59", queryStrings.get(0));
   }
 
   @Test
@@ -94,8 +105,10 @@ public class PatientDataTests {
                     List.of(new USCoreQueryParametersResourceParameterConfig("date", false, List.of("ge${periodStart}", "le${periodEnd}"))))));
 
     ReportCriteria criteria = new ReportCriteria(List.of("measure1"), "2022-01-01T00:00:00.000+00:00", "2022-01-31T23:59:59.000+00:00");
+    PatientData patientData = new PatientData(null, criteria, new Patient(), config, List.of("Patient", "Encounter", "MedicationRequest"));
 
-    String queryString = PatientData.getQuery(config, List.of("measure1"), criteria, "Condition", "patient1");
-    Assert.assertEquals("Condition?patient=Patient/patient1", queryString);
+    List<String> queryStrings = patientData.getQuery(List.of("measure1"), "Condition", "patient1");
+    Assert.assertEquals(1, queryStrings.size());
+    Assert.assertEquals("Condition?patient=Patient/patient1", queryStrings.get(0));
   }
 }


### PR DESCRIPTION
- If "Encounter" resource type is in the data requirements, search for it first
- Build a list of encounter references that can be used later
- Replace ${encounter} token as a separate query string for each encounter

Example/suggested config:
```
  query-parameters:
    nhsnglycemiccontrolhypoglycemicinitialpopulation:   # Measure.identifier.value
      - resourceType: Observation
        parameters:
          - name: category
            single-param: true
            values:
              - laboratory
          - name: date
            values:
              - 'ge${lookBackStart}'
              - 'le${periodEnd}'
      - resourceType: ServiceRequest
        parameters:
          - name: date
            values:
              - 'ge${lookBackStart}'
              - 'le${periodEnd}'
          - name: encounter
            values:
              - '${encounter}'
      - resourceType: MedicationRequest
        parameters:
          - name: date
            values:
              - 'ge${lookBackStart}'
              - 'le${periodEnd}'
          - name: encounter
            values:
              - '${encounter}'
      - resourceType: Encounter
        parameters:
          - name: date
            values:
              - 'ge${lookBackStart}'
              - 'le${periodEnd}'
```

The above example config adds a filter for "encounter" to the `ServiceRequest` and `MedicationRequest` resources, which would cause the system to query for Encounters first, build a list of encounter references that _can_ be searched, and break down the single `GET /ServiceRequest?patient=XXX` request into one `GET /ServiceRequest?patient=XXX&encounter=YYY` request for _each_ encounter returned from the EHR based on the `date` criteria.