### PR TITLE
Adding ability to submit reports to a file system for testing/debugging purposes

### DIFF
--- a/core/src/main/java/com/lantanagroup/link/config/sender/FileSystemSenderConfig.java
+++ b/core/src/main/java/com/lantanagroup/link/config/sender/FileSystemSenderConfig.java
@@ -1,0 +1,25 @@
+package com.lantanagroup.link.config.sender;
+
+import com.lantanagroup.link.config.YamlPropertySourceFactory;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+
+@Getter
+@Setter
+@Configuration
+@ConfigurationProperties(prefix = "sender.file")
+@PropertySource(value = "classpath:application.yml", factory = YamlPropertySourceFactory.class)
+public class FileSystemSenderConfig {
+  private String path;
+  ;
+  private Formats format = Formats.JSON;
+  private Boolean pretty = false;
+
+  public enum Formats {
+    JSON,
+    XML
+  }
+}

--- a/nhsn/src/main/java/com/lantanagroup/link/nhsn/FileSystemSender.java
+++ b/nhsn/src/main/java/com/lantanagroup/link/nhsn/FileSystemSender.java
@@ -1,0 +1,115 @@
+package com.lantanagroup.link.nhsn;
+
+import ca.uhn.fhir.parser.IParser;
+import com.lantanagroup.link.FhirContextProvider;
+import com.lantanagroup.link.FhirDataProvider;
+import com.lantanagroup.link.GenericSender;
+import com.lantanagroup.link.IReportSender;
+import com.lantanagroup.link.config.bundler.BundlerConfig;
+import com.lantanagroup.link.config.sender.FileSystemSenderConfig;
+import lombok.Setter;
+import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.DocumentReference;
+import org.hl7.fhir.r4.model.MeasureReport;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.http.HttpServletRequest;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class FileSystemSender extends GenericSender implements IReportSender {
+  protected static Logger logger = LoggerFactory.getLogger(AzureBlobStorageSender.class);
+
+  @Autowired
+  @Setter
+  private FileSystemSenderConfig config;
+
+  public static String expandEnvVars(String text) {
+    Map<String, String> envMap = System.getenv();
+    for (Map.Entry<String, String> entry : envMap.entrySet()) {
+      String key = entry.getKey();
+      String value = entry.getValue();
+      text = text.replaceAll("%" + key + "%", value);
+    }
+    return text;
+  }
+
+  private FileSystemSenderConfig.Formats getFormat() {
+    if (this.config == null || this.config.getFormat() == null) {
+      return FileSystemSenderConfig.Formats.JSON;
+    }
+    return this.config.getFormat();
+  }
+
+  public Path getFilePath() {
+    String suffix = ".json";
+
+    switch (this.getFormat()) {
+      case XML:
+        suffix = ".xml";
+        break;
+    }
+
+    String fileName = "submission-" + (new SimpleDateFormat("yyyyMMdd'T'HHmmss").format(new Date())) + suffix;
+    String path;
+
+    if (this.config == null || this.config.getPath() == null || this.config.getPath().length() == 0) {
+      logger.info("Not configured with a path to store the submission bundle. Using the system temporary directory");
+      path = System.getProperty("java.io.tmpdir");
+    } else {
+      path = expandEnvVars(this.config.getPath());
+    }
+
+    return Paths.get(path, fileName);
+  }
+
+  @Override
+  public void send(List<MeasureReport> masterMeasureReports, DocumentReference documentReference, HttpServletRequest request, Authentication auth, FhirDataProvider fhirDataProvider, BundlerConfig bundlerConfig) throws Exception {
+    Bundle bundle = this.generateBundle(documentReference, masterMeasureReports, fhirDataProvider, bundlerConfig);
+
+    FileSystemSenderConfig.Formats format = this.getFormat();
+    String content;
+    IParser parser;
+
+    switch (format) {
+      case JSON:
+        parser = FhirContextProvider.getFhirContext().newJsonParser();
+        break;
+      case XML:
+        parser = FhirContextProvider.getFhirContext().newXmlParser();
+        break;
+      default:
+        throw new Exception(String.format("Unexpected format %s", format));
+    }
+
+    if (this.config != null && this.config.getPretty() == true) {
+      parser.setPrettyPrint(true);
+    }
+
+    logger.info(String.format("Encoding submission bundle to %s", format));
+    content = parser.encodeResourceToString(bundle);
+    logger.info(String.format("Done encoding submission bundle to %s", format));
+
+    Path filePath = this.getFilePath();
+    Files.write(filePath, content.getBytes(StandardCharsets.UTF_8));
+
+    logger.info(String.format("Done saving submission bundle/report to %s", filePath.toString()));
+  }
+
+  @Override
+  public String bundle(Bundle bundle, FhirDataProvider fhirProvider, String type) {
+    // TODO: Not sure why this override is required by GenericSender if its not always used
+    return null;
+  }
+}

--- a/nhsn/src/test/java/com/lantanagroup/link/nhsn/FileSystemSenderTests.java
+++ b/nhsn/src/test/java/com/lantanagroup/link/nhsn/FileSystemSenderTests.java
@@ -1,0 +1,29 @@
+package com.lantanagroup.link.nhsn;
+
+import com.lantanagroup.link.config.sender.FileSystemSenderConfig;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.nio.file.Path;
+
+public class FileSystemSenderTests {
+  @Test
+  public void getFilePathTest_NoConfigPath() {
+    FileSystemSender sender = new FileSystemSender();
+    Path path = sender.getFilePath();
+    Assert.assertNotNull(path);
+    Assert.assertNotEquals(0, path.toString().length());
+  }
+
+  @Test
+  public void getFilePathTest_ConfigPath() {
+    FileSystemSenderConfig config = new FileSystemSenderConfig();
+    config.setPath("C:\\users\\test\\some-folder");
+    FileSystemSender sender = new FileSystemSender();
+    sender.setConfig(config);
+
+    Path path = sender.getFilePath();
+    Assert.assertNotNull(path);
+    Assert.assertTrue(path.toString().startsWith(config.getPath()));
+  }
+}

--- a/nhsn/src/test/java/com/lantanagroup/link/nhsn/GenericSenderTests.java
+++ b/nhsn/src/test/java/com/lantanagroup/link/nhsn/GenericSenderTests.java
@@ -4,7 +4,6 @@ import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.rest.client.api.IGenericClient;
 import com.lantanagroup.link.FhirContextProvider;
 import com.lantanagroup.link.FhirDataProvider;
-import com.lantanagroup.link.config.OAuthCredentialModes;
 import com.lantanagroup.link.config.auth.LinkOAuthConfig;
 import com.lantanagroup.link.config.sender.FHIRSenderConfig;
 import org.apache.commons.io.IOUtils;
@@ -104,10 +103,10 @@ public class GenericSenderTests {
     FHIRSender sender = mock(FHIRSender.class);
 
     // Use Mockito for the FHIRSender because we need to mock the getHttpClient method
-    doCallRealMethod().when(sender).setConfig(any());
+    doCallRealMethod().when(sender).setFhirSenderConfig(any());
     // doCallRealMethod().when(sender).sendContent(any(), any(), any(), any());
     doCallRealMethod().when(sender).updateDocumentLocation(any(), any(), any());
-    sender.setConfig(config);
+    sender.setFhirSenderConfig(config);
 
     return sender;
   }


### PR DESCRIPTION
- Config allows setting path, format (JSON vs. XML) and whether or not it should be pretty-formatted
- Defaults to JSON format if not specified
- Defaults to a temporary directory if not specified
- Uses datetime stamp for file name
- Path must exist to store the submission in

Example config:

```
sender:
  file:
    path: c:\data\submission
    pretty: false
    format: JSON
```