### PR TITLE
Persisting individual measure reports immediately after they are evaluated

### DIFF
--- a/api/src/main/java/com/lantanagroup/link/api/MeasureEvaluator.java
+++ b/api/src/main/java/com/lantanagroup/link/api/MeasureEvaluator.java
@@ -67,10 +67,12 @@ public class MeasureEvaluator {
         logger.info("evaluate-measure is being executed with the terminologyEndpoint parameter.");
       }
 
+      logger.info(String.format("Evaluating measure for patient %s and measure %s", patientId, measureId));
+
       FhirDataProvider fhirDataProvider = new FhirDataProvider(this.config.getEvaluationService());
       measureReport = fhirDataProvider.getMeasureReport(measureId, parameters);
 
-      logger.info(String.format("Done executing $evaluate-measure for %s", measureId));
+      logger.info(String.format("Done evaluating measure for patient %s and measure %s", patientId, measureId));
 
       // TODO: commenting out this code because the narrative text isn't being generated, will need to look into this
       // fhirContext.setNarrativeGenerator(new DefaultThymeleafNarrativeGenerator());

--- a/api/src/main/java/com/lantanagroup/link/api/controller/ReportController.java
+++ b/api/src/main/java/com/lantanagroup/link/api/controller/ReportController.java
@@ -343,6 +343,7 @@ public class ReportController extends BaseController {
     this.getFhirDataProvider().updateResource(documentReference);
 
     this.getFhirDataProvider().audit(request, user.getJwt(), FhirHelper.AuditEventTypes.Generate, "Successfully Generated Report");
+    logger.info(String.format("Done generating report %s", documentReference.getIdElement().getIdPart()));
 
     return response;
   }

--- a/core/src/main/java/com/lantanagroup/link/nhsn/FixResourceId.java
+++ b/core/src/main/java/com/lantanagroup/link/nhsn/FixResourceId.java
@@ -26,7 +26,7 @@ public class FixResourceId implements IReportGenerationEvent, IReportGenerationD
     // Fix resource IDs in the patient data bundle that are invalid (longer than 64 characters)
     // (note: this also fixes the references to resources within invalid ids)
     for (PatientOfInterestModel patientOfInterest : context.getPatientsOfInterest()) {
-      logger.info("Patient is: " + patientOfInterest.getId());
+      logger.info(String.format("Fixing resource ids for patient %s resources", patientOfInterest.getId()));
       if (!StringUtils.isEmpty(patientOfInterest.getId())) {
         String patientDataBundleId = ReportIdHelper.getPatientDataBundleId(context.getMasterIdentifierValue(), patientOfInterest.getId());
         IBaseResource patientBundle = fhirDataProvider.getBundleById(patientDataBundleId);


### PR DESCRIPTION
To ideally increase performance and spread the persistence out over time, rather than all at once as a single bundle.