### PR TITLE
Stopwatch enhancements

### DIFF
--- a/api/src/main/java/com/lantanagroup/link/api/MeasureEvaluator.java
+++ b/api/src/main/java/com/lantanagroup/link/api/MeasureEvaluator.java
@@ -1,9 +1,7 @@
 package com.lantanagroup.link.api;
 
 import com.lantanagroup.link.Constants;
-import com.lantanagroup.link.FhirDataProvider;
-import com.lantanagroup.link.ReportIdHelper;
-import com.lantanagroup.link.Stopwatch;
+import com.lantanagroup.link.*;
 import com.lantanagroup.link.config.api.ApiConfig;
 import com.lantanagroup.link.model.PatientOfInterestModel;
 import com.lantanagroup.link.model.ReportContext;
@@ -22,9 +20,10 @@ public class MeasureEvaluator {
   private ReportContext.MeasureContext measureContext;
   private ApiConfig config;
   private String patientId;
+  private StopwatchManager stopwatchManager;
 
-
-  private MeasureEvaluator(ReportCriteria criteria, ReportContext reportContext, ReportContext.MeasureContext measureContext, ApiConfig config, String patientId) {
+  private MeasureEvaluator(StopwatchManager stopwatchManager, ReportCriteria criteria, ReportContext reportContext, ReportContext.MeasureContext measureContext, ApiConfig config, String patientId) {
+    this.stopwatchManager = stopwatchManager;
     this.criteria = criteria;
     this.reportContext = reportContext;
     this.measureContext = measureContext;
@@ -32,8 +31,8 @@ public class MeasureEvaluator {
     this.patientId = patientId;
   }
 
-  public static MeasureReport generateMeasureReport(ReportCriteria criteria, ReportContext reportContext, ReportContext.MeasureContext measureContext, ApiConfig config, PatientOfInterestModel patientOfInterest) {
-    MeasureEvaluator evaluator = new MeasureEvaluator(criteria, reportContext, measureContext, config, patientOfInterest.getId());
+  public static MeasureReport generateMeasureReport(StopwatchManager stopwatchManager, ReportCriteria criteria, ReportContext reportContext, ReportContext.MeasureContext measureContext, ApiConfig config, PatientOfInterestModel patientOfInterest) {
+    MeasureEvaluator evaluator = new MeasureEvaluator(stopwatchManager, criteria, reportContext, measureContext, config, patientOfInterest.getId());
     return evaluator.generateMeasureReport();
   }
 
@@ -74,7 +73,7 @@ public class MeasureEvaluator {
       Date measureEvalStartTime = new Date();
 
       FhirDataProvider fhirDataProvider = new FhirDataProvider(this.config.getEvaluationService());
-      Stopwatch stopwatch = Stopwatch.start("evaluate-measure");
+      Stopwatch stopwatch = this.stopwatchManager.start("evaluate-measure");
       measureReport = fhirDataProvider.getMeasureReport(measureId, parameters);
       stopwatch.stop();
 

--- a/api/src/main/java/com/lantanagroup/link/api/ReportGenerator.java
+++ b/api/src/main/java/com/lantanagroup/link/api/ReportGenerator.java
@@ -3,6 +3,7 @@ package com.lantanagroup.link.api;
 import com.lantanagroup.link.IReportAggregator;
 import com.lantanagroup.link.ReportIdHelper;
 import com.lantanagroup.link.Stopwatch;
+import com.lantanagroup.link.StopwatchManager;
 import com.lantanagroup.link.auth.LinkCredentials;
 import com.lantanagroup.link.config.api.ApiConfig;
 import com.lantanagroup.link.model.ReportContext;
@@ -30,9 +31,10 @@ public class ReportGenerator {
   private LinkCredentials user;
   private ApiConfig config;
   private IReportAggregator reportAggregator;
+  private StopwatchManager stopwatchManager;
 
-
-  public ReportGenerator(ReportContext reportContext, ReportContext.MeasureContext measureContext, ReportCriteria criteria, ApiConfig config, LinkCredentials user, IReportAggregator reportAggregator) {
+  public ReportGenerator(StopwatchManager stopwatchManager, ReportContext reportContext, ReportContext.MeasureContext measureContext, ReportCriteria criteria, ApiConfig config, LinkCredentials user, IReportAggregator reportAggregator) {
+    this.stopwatchManager = stopwatchManager;
     this.reportContext = reportContext;
     this.measureContext = measureContext;
     this.criteria = criteria;
@@ -57,12 +59,12 @@ public class ReportGenerator {
               measureContext.getPatientsOfInterest().parallelStream().filter(patient -> !StringUtils.isEmpty(patient.getId())).map(patient -> {
 
                 logger.info("Generating measure report for patient " + patient);
-                MeasureReport patientMeasureReport = MeasureEvaluator.generateMeasureReport(criteria, reportContext, measureContext, config, patient);
+                MeasureReport patientMeasureReport = MeasureEvaluator.generateMeasureReport(this.stopwatchManager, criteria, reportContext, measureContext, config, patient);
                 String measureReportId = ReportIdHelper.getPatientMeasureReportId(measureContext.getReportId(), patient.getId());
                 patientMeasureReport.setId(measureReportId);
 
                 logger.info(String.format("Persisting patient %s measure report with id %s", patient, measureReportId));
-                Stopwatch stopwatch = Stopwatch.start("store-measure-report");
+                Stopwatch stopwatch = this.stopwatchManager.start("store-measure-report");
                 this.reportContext.getFhirProvider().updateResource(patientMeasureReport);
                 stopwatch.stop();
 

--- a/api/src/main/java/com/lantanagroup/link/api/controller/ReportController.java
+++ b/api/src/main/java/com/lantanagroup/link/api/controller/ReportController.java
@@ -66,6 +66,9 @@ public class ReportController extends BaseController {
   @Autowired
   private ApiInit apiInit;
 
+  @Autowired
+  private StopwatchManager stopwatchManager;
+
   @InitBinder
   public void initBinder(WebDataBinder binder) {
     binder.setDisallowedFields(DISALLOWED_FIELDS);
@@ -163,14 +166,12 @@ public class ReportController extends BaseController {
     return generateResponse(user, request, input.getBundleIds(), input.getPeriodStart(), input.getPeriodEnd(), input.isRegenerate());
   }
 
-
   /**
    * to be invoked when only a multiMeasureBundleId is provided
    *
    * @return Returns a GenerateResponse
    * @throws Exception
    */
-
   @PostMapping("/$generateMultiMeasure")
   public GenerateResponse generateReport(
           @AuthenticationPrincipal LinkCredentials user,
@@ -302,7 +303,7 @@ public class ReportController extends BaseController {
 
       IReportAggregator reportAggregator = (IReportAggregator) context.getBean(Class.forName(reportAggregatorClassName));
 
-      ReportGenerator generator = new ReportGenerator(reportContext, measureContext, criteria, config, user, reportAggregator);
+      ReportGenerator generator = new ReportGenerator(this.stopwatchManager, reportContext, measureContext, criteria, config, user, reportAggregator);
 
       this.eventService.triggerEvent(EventTypes.BeforeMeasureEval, criteria, reportContext, measureContext);
 
@@ -344,6 +345,9 @@ public class ReportController extends BaseController {
 
     this.getFhirDataProvider().audit(request, user.getJwt(), FhirHelper.AuditEventTypes.Generate, "Successfully Generated Report");
     logger.info(String.format("Done generating report %s", documentReference.getIdElement().getIdPart()));
+
+    this.stopwatchManager.print();
+    this.stopwatchManager.reset();
 
     return response;
   }

--- a/core/src/main/java/com/lantanagroup/link/EventService.java
+++ b/core/src/main/java/com/lantanagroup/link/EventService.java
@@ -33,13 +33,16 @@ public class EventService {
   @Setter
   private ApiConfigEvents apiConfigEvents;
 
+  @Autowired
+  private StopwatchManager stopwatchManager;
+
   public void triggerEvent(EventTypes eventType, ReportCriteria criteria, ReportContext reportContext, ReportContext.MeasureContext measureContext) throws Exception {
     List<Object> beans = getBeans(eventType);
     if (beans == null || beans.size() == 0) return;
     for (Object bean : beans) {
       if (bean instanceof IReportGenerationEvent) {
         logger.info("Executing event " + eventType.toString() + " for bean " + bean.toString());
-        Stopwatch stopwatch = Stopwatch.start(String.format("event-%s", bean.getClass().getSimpleName()));
+        Stopwatch stopwatch = this.stopwatchManager.start(String.format("event-%s", bean.getClass().getSimpleName()));
         ((IReportGenerationEvent) bean).execute(criteria, reportContext, measureContext);
         stopwatch.stop();
       } else {
@@ -58,7 +61,7 @@ public class EventService {
     for (Object bean : beans) {
       if (bean instanceof IReportGenerationDataEvent) {
         logger.info("Executing event " + eventType.toString() + " for bean " + bean.toString());
-        Stopwatch stopwatch = Stopwatch.start(String.format("event-%s", bean.getClass().getSimpleName()));
+        Stopwatch stopwatch = this.stopwatchManager.start(String.format("event-%s", bean.getClass().getSimpleName()));
         ((IReportGenerationDataEvent) bean).execute(bundle, criteria, reportContext, measureContext);
         stopwatch.stop();
       } else {

--- a/core/src/main/java/com/lantanagroup/link/StopwatchManager.java
+++ b/core/src/main/java/com/lantanagroup/link/StopwatchManager.java
@@ -25,17 +25,41 @@ public class StopwatchManager {
     StringBuilder output = new StringBuilder();
     output.append("\n");
 
+    output.append("Report generation statistics:\n");
+    output.append("Category\tTotal (s)\tTotal (ms)\tMean (s)\tMean (ms)\tMin (s)\tMin (ms)\tMax (s)\tMax (ms)\n");
+
     this.categories.keySet().forEach(c -> {
-      output.append(String.format("Category \"%s\":\n", c));
-      output.append(String.format("\tCount: %s\n", this.categories.get(c).size()));
 
-      double totalMilliseconds = 0;
+      double totalMillis = 0;
+      Long minMillis = null;
+      Long maxMillis = null;
       for (long duration : this.categories.get(c)) {
-        totalMilliseconds += duration;
-      }
-      double totalSeconds = totalMilliseconds / 1000;
+        totalMillis += duration;
 
-      output.append(String.format("\tTotal Time: %s (secs) %s (millis)\n", totalSeconds, totalMilliseconds));
+        if (minMillis == null || minMillis > duration) {
+          minMillis = duration;
+        }
+        if (maxMillis == null || maxMillis < duration) {
+          maxMillis = duration;
+        }
+      }
+
+      double totalSeconds = totalMillis / 1000;
+      double meanMillis = totalMillis / this.categories.get(c).size();
+      double meanSeconds = meanMillis / 1000;
+      double minSeconds = minMillis / 1000;
+      double maxSeconds = maxMillis / 1000;
+
+      output.append(String.format("%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+              c,
+              totalSeconds,
+              totalMillis,
+              meanSeconds,
+              meanMillis,
+              minSeconds,
+              minMillis,
+              maxSeconds,
+              maxMillis));
     });
 
     logger.info(output.toString());

--- a/core/src/main/java/com/lantanagroup/link/StopwatchManager.java
+++ b/core/src/main/java/com/lantanagroup/link/StopwatchManager.java
@@ -1,0 +1,47 @@
+package com.lantanagroup.link;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+@Component
+public class StopwatchManager {
+  private static final Logger logger = LoggerFactory.getLogger(StopwatchManager.class);
+
+  private ConcurrentHashMap<String, ConcurrentLinkedQueue<Long>> categories = new ConcurrentHashMap<>();
+
+  public synchronized Stopwatch start(String name) {
+    return new Stopwatch(this, name);
+  }
+
+  public ConcurrentHashMap<String, ConcurrentLinkedQueue<Long>> getCategories() {
+    return this.categories;
+  }
+
+  public void print() {
+    StringBuilder output = new StringBuilder();
+    output.append("\n");
+
+    this.categories.keySet().forEach(c -> {
+      output.append(String.format("Category \"%s\":\n", c));
+      output.append(String.format("\tCount: %s\n", this.categories.get(c).size()));
+
+      double totalMilliseconds = 0;
+      for (long duration : this.categories.get(c)) {
+        totalMilliseconds += duration;
+      }
+      double totalSeconds = totalMilliseconds / 1000;
+
+      output.append(String.format("\tTotal Time: %s (secs) %s (millis)\n", totalSeconds, totalMilliseconds));
+    });
+
+    logger.info(output.toString());
+  }
+
+  public void reset() {
+    this.categories = new ConcurrentHashMap<>();
+  }
+}

--- a/query/src/main/java/com/lantanagroup/link/query/uscore/PatientData.java
+++ b/query/src/main/java/com/lantanagroup/link/query/uscore/PatientData.java
@@ -1,11 +1,7 @@
 package com.lantanagroup.link.query.uscore;
 
 import ca.uhn.fhir.rest.client.api.IGenericClient;
-import com.lantanagroup.link.EventService;
-import com.lantanagroup.link.EventTypes;
-import com.lantanagroup.link.Helper;
-import com.lantanagroup.link.ResourceIdChanger;
-import com.lantanagroup.link.Stopwatch;
+import com.lantanagroup.link.*;
 import com.lantanagroup.link.config.query.USCoreConfig;
 import com.lantanagroup.link.config.query.USCoreOtherResourceTypeConfig;
 import com.lantanagroup.link.config.query.USCoreQueryParametersResourceConfig;
@@ -40,8 +36,10 @@ public class PatientData {
   private List<String> encounterReferences = new ArrayList<>();
   private EventService eventService;
   private HashMap<String, Resource> otherResources;
+  private StopwatchManager stopwatchManager;
 
-  public PatientData(HashMap<String, Resource> otherResources, EventService eventService, IGenericClient fhirQueryServer, ReportCriteria criteria, ReportContext context, Patient patient, USCoreConfig usCoreConfig, List<String> resourceTypes) {
+  public PatientData(StopwatchManager stopwatchManager, HashMap<String, Resource> otherResources, EventService eventService, IGenericClient fhirQueryServer, ReportCriteria criteria, ReportContext context, Patient patient, USCoreConfig usCoreConfig, List<String> resourceTypes) {
+    this.stopwatchManager = stopwatchManager;
     this.otherResources = otherResources;
     this.eventService = eventService;
     this.fhirQueryServer = fhirQueryServer;
@@ -257,7 +255,7 @@ public class PatientData {
       logger.warn("No queries generated based on resource types and configuration");
     }
 
-    Stopwatch stopwatch = Stopwatch.start("query-resources-other");
+    Stopwatch stopwatch = this.stopwatchManager.start("query-resources-other");
     this.getOtherResources();
     stopwatch.stop();
   }
@@ -309,7 +307,7 @@ public class PatientData {
       }
 
       resourcesToGet.keySet().stream().forEach(resourceType -> {
-        Stopwatch stopwatch = Stopwatch.start(String.format("query-resources-other-%s", resourceType));
+        Stopwatch stopwatch = this.stopwatchManager.start(String.format("query-resources-other-%s", resourceType));
         List<String> allResourceIds = resourcesToGet.get(resourceType);
 
         // Determine if other resource was already retrieved by as part of another patient query

--- a/query/src/test/java/com/lantanagroup/link/query/uscore/PatientDataTests.java
+++ b/query/src/test/java/com/lantanagroup/link/query/uscore/PatientDataTests.java
@@ -1,5 +1,6 @@
 package com.lantanagroup.link.query.uscore;
 
+import com.lantanagroup.link.StopwatchManager;
 import com.lantanagroup.link.config.query.USCoreConfig;
 import com.lantanagroup.link.config.query.USCoreQueryParametersResourceConfig;
 import com.lantanagroup.link.config.query.USCoreQueryParametersResourceParameterConfig;
@@ -24,7 +25,7 @@ public class PatientDataTests {
                             new USCoreQueryParametersResourceParameterConfig("date", false, List.of("ge${periodStart}", "le${periodEnd}"))))));
 
     ReportCriteria criteria = new ReportCriteria(List.of("measure1"), "2022-01-01T00:00:00.000+00:00", "2022-01-31T23:59:59.000+00:00");
-    PatientData patientData = new PatientData(new HashMap<>(), null, null, criteria, null, new Patient(), config, List.of("Patient", "Encounter", "MedicationRequest"));
+    PatientData patientData = new PatientData(new StopwatchManager(), new HashMap<>(), null, null, criteria, null, new Patient(), config, List.of("Patient", "Encounter", "MedicationRequest"));
 
     List<String> queryStrings = patientData.getQuery(List.of("measure1"), "Observation", "patient1");
     Assert.assertEquals(1, queryStrings.size());
@@ -41,7 +42,7 @@ public class PatientDataTests {
                     List.of(new USCoreQueryParametersResourceParameterConfig("date", false, List.of("ge${lookBackStart}", "le${periodEnd}"))))));
 
     ReportCriteria criteria = new ReportCriteria(List.of("measure1"), "2022-01-01T00:00:00.000+00:00", "2022-01-31T23:59:59.000+00:00");
-    PatientData patientData = new PatientData(new HashMap<>(), null, null, criteria, null, new Patient(), config, List.of("Patient", "Encounter", "MedicationRequest"));
+    PatientData patientData = new PatientData(new StopwatchManager(), new HashMap<>(), null, null, criteria, null, new Patient(), config, List.of("Patient", "Encounter", "MedicationRequest"));
 
     List<String> queryStrings = patientData.getQuery(List.of("measure1"), "Observation", "patient1");
     Assert.assertEquals(1, queryStrings.size());
@@ -57,7 +58,7 @@ public class PatientDataTests {
                     List.of(new USCoreQueryParametersResourceParameterConfig("date", false, List.of("ge${lookBackStart}", "le${periodEnd}"))))));
 
     ReportCriteria criteria = new ReportCriteria(List.of("measure1"), "2022-01-01T00:00:00.000+00:00", "2022-01-31T23:59:59.000+00:00");
-    PatientData patientData = new PatientData(new HashMap<>(), null, null, criteria, null, new Patient(), config, List.of("Patient", "Encounter", "MedicationRequest"));
+    PatientData patientData = new PatientData(new StopwatchManager(), new HashMap<>(), null, null, criteria, null, new Patient(), config, List.of("Patient", "Encounter", "MedicationRequest"));
 
     List<String> queryStrings = patientData.getQuery(List.of("measure1"), "Observation", "patient1");
     Assert.assertEquals(1, queryStrings.size());
@@ -73,7 +74,7 @@ public class PatientDataTests {
                     List.of(new USCoreQueryParametersResourceParameterConfig("category", true, List.of("labs"))))));
 
     ReportCriteria criteria = new ReportCriteria(List.of("measure1"), "2022-01-01T00:00:00.000+00:00", "2022-01-31T23:59:59.000+00:00");
-    PatientData patientData = new PatientData(new HashMap<>(), null, null, criteria, null, new Patient(), config, List.of("Patient", "Encounter", "MedicationRequest"));
+    PatientData patientData = new PatientData(new StopwatchManager(), new HashMap<>(), null, null, criteria, null, new Patient(), config, List.of("Patient", "Encounter", "MedicationRequest"));
 
     List<String> queryStrings = patientData.getQuery(List.of("measure1"), "MedicationRequest", "patient1");
     Assert.assertEquals(1, queryStrings.size());
@@ -89,7 +90,7 @@ public class PatientDataTests {
                     List.of(new USCoreQueryParametersResourceParameterConfig("date", false, List.of("ge${periodStart}", "le${periodEnd}"))))));
 
     ReportCriteria criteria = new ReportCriteria(List.of("measure1"), "2022-01-01T00:00:00.000+00:00", "2022-01-31T23:59:59.000+00:00");
-    PatientData patientData = new PatientData(new HashMap<>(), null, null, criteria, null, new Patient(), config, List.of("Patient", "Encounter", "MedicationRequest"));
+    PatientData patientData = new PatientData(new StopwatchManager(), new HashMap<>(), null, null, criteria, null, new Patient(), config, List.of("Patient", "Encounter", "MedicationRequest"));
 
     List<String> queryStrings = patientData.getQuery(List.of("measure1"), "Encounter", "patient1");
     Assert.assertEquals(1, queryStrings.size());
@@ -105,7 +106,7 @@ public class PatientDataTests {
                     List.of(new USCoreQueryParametersResourceParameterConfig("date", false, List.of("ge${periodStart}", "le${periodEnd}"))))));
 
     ReportCriteria criteria = new ReportCriteria(List.of("measure1"), "2022-01-01T00:00:00.000+00:00", "2022-01-31T23:59:59.000+00:00");
-    PatientData patientData = new PatientData(new HashMap<>(), null, null, criteria, null, new Patient(), config, List.of("Patient", "Encounter", "MedicationRequest"));
+    PatientData patientData = new PatientData(new StopwatchManager(), new HashMap<>(), null, null, criteria, null, new Patient(), config, List.of("Patient", "Encounter", "MedicationRequest"));
 
     List<String> queryStrings = patientData.getQuery(List.of("measure1"), "Condition", "patient1");
     Assert.assertEquals(1, queryStrings.size());


### PR DESCRIPTION
Keep track of stopwatch categories over time
Print out statistics and reset at end of report generation
A couple columns/statistics not calculating quite right, need to figure out why...
Total time doesn't account for multiple threads running at same time... 
Entire report only took ~30 seconds to run, but one of the 257 seconds, because they ran in parallel.

Example output:
```
Report generation statistics:
Category	Total (s)	Total (ms)	Mean (s)	Mean (ms)	Min (s)	Min (ms)	Max (s)	Max (ms)
query-resources-other	1.014	1014.0	0.04225	42.25	0.0	0	0.0	352
event-EncounterStatusTransformer	0.001	1.0	4.0E-5	0.04	0.0	0	0.0	1
query-resources-other-Location	0.829	829.0	0.1658	165.8	0.0	150	0.0	180
event-ApplyConceptMaps	4.746	4746.0	0.18984	189.84	0.0	118	0.0	474
store-patient-data	4.299	4299.0	0.17196	171.96	0.0	121	0.0	686
evaluate-measure	14.92	14920.0	0.3174468085106383	317.4468085106383	0.0	111	0.0	797
query-resources-patient	31.334	31334.0	1.2533599999999998	1253.36	0.0	157	2.0	2411
query-resources	257.976	257976.0	10.319040000000001	10319.04	0.0	967	23.0	23464
store-measure-report	16.852	16852.0	0.3585531914893617	358.5531914893617	0.0	205	0.0	719
query-patient	22.533	22533.0	0.8666538461538462	866.6538461538462	0.0	113	2.0	2386
event-CopyLocationIdentifierToType	0.001	1.0	4.0E-5	0.04	0.0	0	0.0	1
event-PatientDataResourceFilter	0.006	6.0	3.2432432432432436E-5	0.032432432432432434	0.0	0	0.0	3
event-FixResourceId	3.988	3988.0	0.1533846153846154	153.3846153846154	0.0	0	3.0	3972
query-resources-other-Specimen	0.168	168.0	0.168	168.0	0.0	168	0.0	168
```