### PR TITLE
Period Date Fix

### DIFF
--- a/api/src/main/resources/swagger.yml
+++ b/api/src/main/resources/swagger.yml
@@ -1037,6 +1037,7 @@ components:
         - com.lantanagroup.link.events.CopyLocationIdentifierToType
         - com.lantanagroup.link.events.EncounterStatusTransformer
         - com.lantanagroup.link.events.FixResourceId
+        - com.lantanagroup.link.events.FixPeriodDates
         - com.lantanagroup.link.events.PatientDataResourceFilter
     QueryList:
       type: object

--- a/core/src/main/java/com/lantanagroup/link/FhirScanner.java
+++ b/core/src/main/java/com/lantanagroup/link/FhirScanner.java
@@ -2,6 +2,7 @@ package com.lantanagroup.link;
 
 import org.hl7.fhir.r4.model.CodeableConcept;
 import org.hl7.fhir.r4.model.Coding;
+import org.hl7.fhir.r4.model.Period;
 import org.hl7.fhir.r4.model.Reference;
 
 import java.lang.reflect.Array;
@@ -21,6 +22,12 @@ public class FhirScanner {
     List<Reference> references = new ArrayList<>();
     scanInstance(obj, Reference.class, Collections.newSetFromMap(new IdentityHashMap<>()), references);
     return references;
+  }
+
+  public static List<Period> findPeriods(Object obj) {
+    List<Period> periods = new ArrayList<>();
+    scanInstance(obj, Period.class, Collections.newSetFromMap(new IdentityHashMap<>()), periods);
+    return periods;
   }
 
   /**

--- a/core/src/main/java/com/lantanagroup/link/PeriodDateFixer.java
+++ b/core/src/main/java/com/lantanagroup/link/PeriodDateFixer.java
@@ -1,0 +1,57 @@
+package com.lantanagroup.link;
+
+import ca.uhn.fhir.model.api.TemporalPrecisionEnum;
+import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.DateTimeType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.Date;
+import java.util.TimeZone;
+
+public class PeriodDateFixer
+{
+  private Bundle _bundle;
+  private Logger _logger = LoggerFactory.getLogger(PeriodDateFixer.class);
+
+  public PeriodDateFixer(Bundle bundle) {
+    _bundle = bundle;
+  }
+
+  public void FixDates()
+  {
+    var periodsInBundle = FhirScanner.findPeriods(_bundle);
+
+    periodsInBundle.forEach(p -> {
+
+      //Fix the Start Date
+      var start = p.getStart();
+      start = FixDate(start);
+
+      //Fix the End Date
+      var end = p.getEnd();
+      end = FixDate(end);
+
+      var tz = TimeZone.getTimeZone(ZoneId.ofOffset("", ZoneOffset.UTC));
+
+      //Set the fixed datetimes back into the Period, which should always include a time component if one was missing.
+      p.setStartElement(new DateTimeType(start, TemporalPrecisionEnum.SECOND, tz));
+      p.setEndElement(new DateTimeType(end, TemporalPrecisionEnum.SECOND, tz));
+
+    });
+  }
+
+  private Date FixDate(Date date)
+  {
+    //Convert the deprecated Date object to the modern LocalDateTime, setting the timezone to UTC
+    ZonedDateTime zdt = ZonedDateTime.ofInstant(date.toInstant(), ZoneOffset.UTC);
+
+    //convert it back into a java.util.Date object
+    var newDT = new java.util.Date(zdt.getYear()-1900, zdt.getMonthValue()-1, zdt.getDayOfMonth(), zdt.getHour(), zdt.getMinute(), zdt.getSecond());
+
+    return newDT;
+  }
+}

--- a/core/src/main/java/com/lantanagroup/link/events/FixPeriodDates.java
+++ b/core/src/main/java/com/lantanagroup/link/events/FixPeriodDates.java
@@ -1,0 +1,30 @@
+package com.lantanagroup.link.events;
+
+import com.lantanagroup.link.IReportGenerationDataEvent;
+import com.lantanagroup.link.PeriodDateFixer;
+import com.lantanagroup.link.db.TenantService;
+import com.lantanagroup.link.model.ReportContext;
+import com.lantanagroup.link.model.ReportCriteria;
+import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.DomainResource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+public class FixPeriodDates implements IReportGenerationDataEvent
+{
+  private static final Logger logger = LoggerFactory.getLogger(FixPeriodDates.class);
+
+  public void execute(TenantService tenantService, Bundle data, ReportCriteria criteria, ReportContext context, ReportContext.MeasureContext measureContext)
+  {
+    logger.info("Called: " + FixPeriodDates.class.getName());
+    PeriodDateFixer fixer = new PeriodDateFixer(data);
+    fixer.FixDates();
+  }
+
+  public void execute(TenantService tenantService, List<DomainResource> resourceList, ReportCriteria criteria, ReportContext context, ReportContext.MeasureContext measureContext) {
+    throw new RuntimeException("Not Implemented yet.");
+  }
+}
+

--- a/core/src/test/java/com/lantanagroup/link/PeriodDateFixerTests.java
+++ b/core/src/test/java/com/lantanagroup/link/PeriodDateFixerTests.java
@@ -1,0 +1,67 @@
+package com.lantanagroup.link;
+
+import ca.uhn.fhir.model.api.TemporalPrecisionEnum;
+import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.DateTimeType;
+import org.hl7.fhir.r4.model.Encounter;
+import org.hl7.fhir.r4.model.Period;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.text.ParsePosition;
+import java.text.SimpleDateFormat;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.Date;
+import java.util.List;
+import java.util.TimeZone;
+
+public class PeriodDateFixerTests {
+  @Test
+  public void findPeriodsBundleTest() {
+    Bundle bundle = new Bundle();
+    Encounter enc = new Encounter();
+    enc.getPeriod().setStartElement(new DateTimeType("2023-05-25"));
+    enc.getPeriod().setEndElement(new DateTimeType("2023-05-25T12:00:00Z"));
+    bundle.addEntry().setResource(enc);
+
+    List<Period> periods = FhirScanner.findPeriods(bundle);
+    Assert.assertEquals(1, periods.size());
+  }
+
+  @Test
+  public void fixDatesTest()
+  {
+    Bundle bundle = new Bundle();
+    Encounter enc = new Encounter();
+
+    var tz = TimeZone.getTimeZone(ZoneId.ofOffset("", ZoneOffset.UTC));
+    enc.getPeriod().setStartElement(new DateTimeType(new Date(2023-1900, 5-1, 25), TemporalPrecisionEnum.DAY, tz));
+    var startString = enc.getPeriod().getStartElement().asStringValue();
+
+    enc.getPeriod().setEndElement(new DateTimeType("2023-05-25T12:00:00+00:00"));
+    var endString = enc.getPeriod().getEndElement().asStringValue();
+
+    bundle.addEntry().setResource(enc);
+
+    var periods = FhirScanner.findPeriods(bundle);
+
+    var fixer = new PeriodDateFixer(bundle);
+    fixer.FixDates();
+
+    var period = periods.get(0);
+    SimpleDateFormat isoFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
+    isoFormat.setTimeZone(tz);
+    var start = isoFormat.parse("2023-05-25T00:00:00Z", new ParsePosition(0));
+
+    isoFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
+    isoFormat.setTimeZone(tz);
+    var end = isoFormat.parse("2023-05-25T12:00:00Z", new ParsePosition(0));
+
+    Assert.assertEquals(start, period.getStart());
+    Assert.assertNotEquals(startString, period.getStartElement().asStringValue());
+
+    Assert.assertEquals(end, period.getEnd());
+    Assert.assertEquals(endString, period.getEndElement().asStringValue());
+  }
+}


### PR DESCRIPTION
Added logic to fix the dates on the encounter periords, primarily when a start date is missing a time component. The code will construct every start/end date in a way that ensure thats a proper time is added if not present.