### PR TITLE
Fixes to bundling and validation

### DIFF
--- a/api/src/main/java/com/lantanagroup/link/api/controller/ValidationController.java
+++ b/api/src/main/java/com/lantanagroup/link/api/controller/ValidationController.java
@@ -1,0 +1,162 @@
+package com.lantanagroup.link.api.controller;
+
+import com.lantanagroup.link.EventService;
+import com.lantanagroup.link.FhirContextProvider;
+import com.lantanagroup.link.Helper;
+import com.lantanagroup.link.config.api.ApiConfig;
+import com.lantanagroup.link.db.SharedService;
+import com.lantanagroup.link.db.TenantService;
+import com.lantanagroup.link.db.model.Report;
+import com.lantanagroup.link.validation.Validator;
+import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.IntegerType;
+import org.hl7.fhir.r4.model.OperationOutcome;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/{tenantId}/validate")
+public class ValidationController {
+
+  private static final Logger logger = LoggerFactory.getLogger(ValidationController.class);
+  @Autowired
+  private SharedService sharedService;
+  @Autowired
+  private ApiConfig config;
+  @Autowired
+  private EventService eventService;
+
+  private OperationOutcome validateBundle(TenantService tenantService, Bundle bundle, OperationOutcome.IssueSeverity severity) {
+    try {
+      Validator validator = new Validator(tenantService.getConfig().getValidation());
+      OperationOutcome outcome = validator.validate(bundle, severity);
+      Path tempFile = Files.createTempFile(null, ".json");
+      try (FileWriter fw = new FileWriter(tempFile.toFile())) {
+        FhirContextProvider.getFhirContext().newJsonParser().encodeResourceToWriter(outcome, fw);
+      }
+      logger.info("Validation results saved to {}", tempFile);
+
+      // Add an extension (which doesn't formally exist) that shows the total issues
+      outcome.addExtension("http://nhsnlink.org/oo-total", new IntegerType(outcome.getIssue().size()));
+
+      // Don't return more than 2k issues to the response... We can just look at the temp file instead
+      if (outcome.getIssue().size() > 2000) {
+        outcome.setIssue(null);
+      } else {
+        outcome.getIssue().forEach(i -> {
+          i.setExtension(null);
+          i.setDetails(null);
+          if (i.getLocation().size() == 2) {
+            i.getLocation().remove(1);    // Remove the line number - it's useless.
+          }
+        });
+      }
+
+      return outcome;
+    } catch (IOException ex) {
+      logger.error("Error storing bundle validation results to file", ex);
+      throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+  }
+
+  /**
+   * Validates a Bundle provided in the request body
+   *
+   * @param tenantId The id of the tenant
+   * @param severity The minimum severity level to report on
+   * @return Returns an OperationOutcome resource that provides details about each of the issues found
+   */
+  @PostMapping
+  public OperationOutcome validate(@PathVariable String tenantId, @RequestBody Bundle bundle, @RequestParam(defaultValue = "ERROR") OperationOutcome.IssueSeverity severity) {
+    TenantService tenantService = TenantService.create(this.sharedService, tenantId);
+
+    if (tenantService == null) {
+      throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Tenant not found");
+    }
+
+    return this.validateBundle(tenantService, bundle, severity);
+  }
+
+  private String getValidationSummary(OperationOutcome outcome) {
+    List<String> uniqueMessages = new ArrayList<>();
+
+    for (OperationOutcome.OperationOutcomeIssueComponent issue : outcome.getIssue()) {
+      String message = issue.getSeverity().toString() + ": " + issue.getDiagnostics();
+      if (!uniqueMessages.contains(message)) {
+        uniqueMessages.add(message);
+      }
+    }
+
+    if (!uniqueMessages.isEmpty()) {
+      return "* " + String.join("\n* ", uniqueMessages);
+    }
+
+    return "No issues found";
+  }
+
+  /**
+   * Validates a Bundle provided in the request body
+   *
+   * @param tenantId The id of the tenant
+   * @param severity The minimum severity level to report on
+   * @return Returns an OperationOutcome resource that provides details about each of the issues found
+   */
+  @PostMapping("/summary")
+  public String validateSummary(@PathVariable String tenantId, @RequestBody Bundle bundle, @RequestParam(defaultValue = "ERROR") OperationOutcome.IssueSeverity severity) {
+    OperationOutcome outcome = this.validate(tenantId, bundle, severity);
+    return this.getValidationSummary(outcome);
+  }
+
+  /**
+   * Validates a generated report
+   *
+   * @param tenantId The id of the tenant
+   * @param reportId The id of the report to validate against
+   * @param severity The minimum severity level to report on
+   * @return Returns an OperationOutcome resource that provides details about each of the issues found
+   * @throws IOException
+   */
+  @GetMapping("/{reportId}")
+  public OperationOutcome validate(@PathVariable String tenantId, @PathVariable String reportId, @RequestParam(defaultValue = "ERROR") OperationOutcome.IssueSeverity severity) throws IOException {
+    TenantService tenantService = TenantService.create(this.sharedService, tenantId);
+
+    if (tenantService == null) {
+      throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Tenant not found");
+    }
+
+    Report report = tenantService.getReport(reportId);
+
+    if (report == null) {
+      throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Report not found");
+    }
+
+    Bundle submissionBundle = Helper.generateBundle(tenantService, report, this.eventService, this.config);
+    return this.validateBundle(tenantService, submissionBundle, severity);
+  }
+
+  /**
+   * Provides a summary of unique messages from validation results
+   *
+   * @param tenantId The id of the tenant
+   * @param reportId The id of the report to validate against
+   * @param severity The minimum severity level to report on
+   * @return Returns a plain string, each line representing a single message (including severity)
+   * @throws IOException
+   */
+  @GetMapping("/{reportId}/summary")
+  public String validateSummary(@PathVariable String tenantId, @PathVariable String reportId, @RequestParam(defaultValue = "ERROR") OperationOutcome.IssueSeverity severity) throws IOException {
+    OperationOutcome outcome = this.validate(tenantId, reportId, severity);
+    return this.getValidationSummary(outcome);
+  }
+}

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -70,3 +70,6 @@ data-governance:
   census-list-retention:
   patient-data-retention: P0Y3M     # default of three months
   report-retention:
+sender:
+  file:
+    path: '%TEMP%'

--- a/api/src/main/resources/swagger.yml
+++ b/api/src/main/resources/swagger.yml
@@ -580,70 +580,6 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
-  /api/{tenantId}/report/$validate:
-    post:
-      tags:
-        - Reports
-      summary: Validate a report provided in the request body
-      operationId: validateRequest
-      parameters:
-        - name: tenantId
-          in: path
-          description: The id of the tenant, used to determine validation options
-          required: true
-          schema:
-            type: string
-      requestBody:
-        required: true
-        content:
-          'application/json':
-            schema:
-              $ref: '#/components/schemas/FHIR.Bundle'
-      responses:
-        '200':
-          description: successful response
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/FHIR.OperationOutcome'
-        '401':
-          $ref: '#/components/responses/Unauthorized'
-        '403':
-          $ref: '#/components/responses/Unauthorized'
-        '404':
-          $ref: '#/components/responses/NotFound'
-  /api/{tenantId}/report/{reportId}/$validate:
-    get:
-      tags:
-        - Reports
-      summary: Validate the report against FHIR standards and implementation guides
-      operationId: validateReport
-      parameters:
-        - name: tenantId
-          in: path
-          description: The id of the tenant in which the report resides, and used to determine validation options
-          required: true
-          schema:
-            type: string
-        - name: reportId
-          in: path
-          description: The logical id of the report to submit
-          required: true
-          schema:
-            type: string
-      responses:
-        '200':
-          description: successful response
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/FHIR.OperationOutcome'
-        '401':
-          $ref: '#/components/responses/Unauthorized'
-        '403':
-          $ref: '#/components/responses/Unauthorized'
-        '404':
-          $ref: '#/components/responses/NotFound'
   /api/{tenantId}/report/{reportId}/aggregate:
     get:
       tags:
@@ -776,6 +712,170 @@ paths:
             'application/json':
               schema:
                 $ref: '#/components/schemas/FHIR.MeasureReport'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+  /api/{tenantId}/validate:
+    post:
+      tags:
+        - Validation
+      summary: Validate a report provided in the request body
+      operationId: validateRequest
+      parameters:
+        - name: tenantId
+          in: path
+          description: The id of the tenant, used to determine validation options
+          required: true
+          schema:
+            type: string
+        - name: severity
+          in: query
+          schema:
+            type: string
+            default: ERROR
+            enum: [ ERROR, WARN, INFO ]
+      requestBody:
+        description: The FHIR Bundle to validate
+        required: true
+        content:
+          'application/json':
+            schema:
+              $ref: '#/components/schemas/FHIR.Bundle'
+      responses:
+        '200':
+          description: successful response
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/FHIR.OperationOutcome'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+  /api/{tenantId}/validate/summary:
+    post:
+      tags:
+        - Validation
+      summary: Provides a summary of unique messages from validation results of the request body
+      operationId: validateRequestSummary
+      parameters:
+        - name: tenantId
+          in: path
+          description: The id of the tenant in which the report resides, and used to determine validation options
+          required: true
+          schema:
+            type: string
+        - name: severity
+          in: query
+          schema:
+            type: string
+            default: ERROR
+            enum: [ ERROR, WARN, INFO ]
+      requestBody:
+        description: The FHIR Bundle to validate
+        required: true
+        content:
+          'application/json':
+            schema:
+              $ref: '#/components/schemas/FHIR.Bundle'
+      responses:
+        '200':
+          description: successful response
+          content:
+            'text/plain':
+              schema:
+                type: string
+                example: |
+                  * Device.deviceName.type: minimum required = 1, but only found 0 (from http://hl7.org/fhir/StructureDefinition/Device)
+                  * Slicing cannot be evaluated: Problem with use of resolve() - profile [CanonicalType[http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-softwaresystem]] on MeasureReport.extension:software could not be resolved (@char 1)
+                  * MedicationRequest.requester: minimum required = 1, but only found 0 (from http://hl7.org/fhir/us/core/StructureDefinition/us-core-medicationrequest)
+                  * if a date has a time, it must have a timezone
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+  /api/{tenantId}/validate/{reportId}:
+    get:
+      tags:
+        - Validation
+      summary: Validate a generated report
+      operationId: validateReport
+      parameters:
+        - name: tenantId
+          in: path
+          description: The id of the tenant in which the report resides, and used to determine validation options
+          required: true
+          schema:
+            type: string
+        - name: reportId
+          in: path
+          description: The logical id of the report to submit
+          required: true
+          schema:
+            type: string
+        - name: severity
+          in: query
+          schema:
+            type: string
+            default: ERROR
+            enum: [ ERROR, WARN, INFO ]
+      responses:
+        '200':
+          description: successful response
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/FHIR.OperationOutcome'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+  /api/{tenantId}/validate/{reportId}/summary:
+    get:
+      tags:
+        - Validation
+      summary: Provides a summary of unique messages from validation results
+      operationId: validateReportSummary
+      parameters:
+        - name: tenantId
+          in: path
+          description: The id of the tenant in which the report resides, and used to determine validation options
+          required: true
+          schema:
+            type: string
+        - name: reportId
+          in: path
+          description: The logical id of the report to submit
+          required: true
+          schema:
+            type: string
+        - name: severity
+          in: query
+          schema:
+            type: string
+            default: ERROR
+            enum: [ ERROR, WARN, INFO ]
+      responses:
+        '200':
+          description: successful response
+          content:
+            'text/plain':
+              schema:
+                type: string
+                example: |
+                  * Device.deviceName.type: minimum required = 1, but only found 0 (from http://hl7.org/fhir/StructureDefinition/Device)
+                  * Slicing cannot be evaluated: Problem with use of resolve() - profile [CanonicalType[http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-softwaresystem]] on MeasureReport.extension:software could not be resolved (@char 1)
+                  * MedicationRequest.requester: minimum required = 1, but only found 0 (from http://hl7.org/fhir/us/core/StructureDefinition/us-core-medicationrequest)
+                  * if a date has a time, it must have a timezone
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':

--- a/core/src/main/java/com/lantanagroup/link/Helper.java
+++ b/core/src/main/java/com/lantanagroup/link/Helper.java
@@ -3,10 +3,15 @@ package com.lantanagroup.link;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.lantanagroup.link.config.api.ApiConfig;
+import com.lantanagroup.link.db.TenantService;
+import com.lantanagroup.link.db.model.Aggregate;
+import com.lantanagroup.link.db.model.Report;
 import com.lantanagroup.link.model.ApiInfoModel;
 import com.microsoft.sqlserver.jdbc.SQLServerDriver;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.text.StringEscapeUtils;
+import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.CapabilityStatement;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -182,5 +187,14 @@ public class Helper {
       text = text.replace("%" + key + "%", value);
     }
     return text;
+  }
+
+  public static Bundle generateBundle(TenantService tenantService, Report report, EventService eventService, ApiConfig config) {
+    FhirBundler bundler = new FhirBundler(eventService, tenantService, config);
+    logger.info("Building Bundle for MeasureReport to send...");
+    List<Aggregate> aggregates = tenantService.getAggregates(report.getId());
+    Bundle bundle = bundler.generateBundle(aggregates, report);
+    logger.info(String.format("Done building Bundle for MeasureReport with %s entries", bundle.getEntry().size()));
+    return bundle;
   }
 }

--- a/core/src/main/java/com/lantanagroup/link/Helper.java
+++ b/core/src/main/java/com/lantanagroup/link/Helper.java
@@ -24,10 +24,7 @@ import java.text.SimpleDateFormat;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.List;
+import java.util.*;
 
 public class Helper {
   private static final Logger logger = LoggerFactory.getLogger(Helper.class);
@@ -175,5 +172,15 @@ public class Helper {
       logger.warn("Parsing database connection string failed", e);
       return null;
     }
+  }
+
+  public static String expandEnvVars(String text) {
+    Map<String, String> envMap = System.getenv();
+    for (Map.Entry<String, String> entry : envMap.entrySet()) {
+      String key = entry.getKey();
+      String value = entry.getValue();
+      text = text.replace("%" + key + "%", value);
+    }
+    return text;
   }
 }

--- a/nhsn/src/main/java/com/lantanagroup/link/nhsn/FileSystemSender.java
+++ b/nhsn/src/main/java/com/lantanagroup/link/nhsn/FileSystemSender.java
@@ -3,6 +3,7 @@ package com.lantanagroup.link.nhsn;
 import ca.uhn.fhir.parser.IParser;
 import com.lantanagroup.link.FhirContextProvider;
 import com.lantanagroup.link.GenericSender;
+import com.lantanagroup.link.Helper;
 import com.lantanagroup.link.IReportSender;
 import com.lantanagroup.link.auth.LinkCredentials;
 import com.lantanagroup.link.config.sender.FileSystemSenderConfig;
@@ -31,7 +32,6 @@ import java.security.*;
 import java.text.SimpleDateFormat;
 import java.util.Arrays;
 import java.util.Date;
-import java.util.Map;
 
 import static com.google.common.primitives.Bytes.concat;
 
@@ -44,16 +44,6 @@ public class FileSystemSender extends GenericSender implements IReportSender {
   private FileSystemSenderConfig config;
 
   private SecureRandom random = new SecureRandom();
-
-  public static String expandEnvVars(String text) {
-    Map<String, String> envMap = System.getenv();
-    for (Map.Entry<String, String> entry : envMap.entrySet()) {
-      String key = entry.getKey();
-      String value = entry.getValue();
-      text = text.replaceAll("%" + key + "%", value);
-    }
-    return text;
-  }
 
   private FileSystemSenderConfig.Formats getFormat() {
     if (this.config == null || this.config.getFormat() == null) {
@@ -78,7 +68,7 @@ public class FileSystemSender extends GenericSender implements IReportSender {
       logger.info("Not configured with a path to store the submission bundle. Using the system temporary directory");
       throw new IllegalArgumentException("Error: Not configured with a path in FileSystemSender to store the submission bundle");
     } else {
-      path = expandEnvVars(this.config.getPath());
+      path = Helper.expandEnvVars(this.config.getPath());
     }
 
     return Paths.get(path, fileName);


### PR DESCRIPTION
* Defaulting file sender path to temp directory
* Fixed bug in resolving variables in the sending path. `replaceAll` uses regex in the replacing value, which caused problems.
* Removing logic to clean profiles from resources and adding explicit profile assertions. This is now being handled by the results of the CQF-Ruler (as part of the CQL logic).
* Adding warning statement in logs when resources exist in the bundle without profile assertions, which would cause them not to be validated.
* Moving `expandEnVars` to helper class so that it may be re-used by other classes in the future
* Refactoring validation operations into its own controller and route
* Adding summary operations to provide simple summarization of validation issues