### PR TITLE
LNK-1198 Provide information to user when requests result in deserialization exception

### DIFF
--- a/core/src/main/java/com/lantanagroup/link/spring/YamlMessageConverter.java
+++ b/core/src/main/java/com/lantanagroup/link/spring/YamlMessageConverter.java
@@ -1,5 +1,6 @@
 package com.lantanagroup.link.spring;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import org.springframework.http.MediaType;
 import org.springframework.http.converter.json.AbstractJackson2HttpMessageConverter;
@@ -10,5 +11,6 @@ public class YamlMessageConverter extends AbstractJackson2HttpMessageConverter {
     // cased property names. Can't use a mix of strategies though, so defaulting to the strategy that
     // most closely aligns with the property names defined on the classes
     super(new YAMLMapper(), MediaType.parseMediaType("application/x-yaml"));
+    this.getObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
   }
 }


### PR DESCRIPTION
* When HttpMessageNotReadableException is thrown, pass the message from the exception to the user so that they know what went wrong
* Ignoring properties that don't exist from YAML deserialization