### PR TITLE
BulkStatus - Remove TenantId

### DIFF
--- a/core/src/main/java/com/lantanagroup/link/db/BulkStatusService.java
+++ b/core/src/main/java/com/lantanagroup/link/db/BulkStatusService.java
@@ -50,8 +50,7 @@ public class BulkStatusService {
     try (Connection conn = this.dataSource.getConnection()) {
       assert conn != null;
 
-      PreparedStatement ps = conn.prepareStatement("SELECT id, tenantId, statusUrl, [status], [date] FROM [dbo].[bulkStatus] WHERE tenantId = ?");
-      ps.setNString(1, tenantConfig.getId());
+      PreparedStatement ps = conn.prepareStatement("SELECT id, statusUrl, [status], [date] FROM [dbo].[bulkStatus]");
 
       ResultSet rs = ps.executeQuery();
 
@@ -61,10 +60,9 @@ public class BulkStatusService {
         var status = new BulkStatus();
 
         status.setId(rs.getString(1));
-        status.setTenantId(rs.getString(2));
-        status.setStatusUrl(rs.getString(3));
-        status.setStatus(rs.getString(4));
-        status.setLastChecked(new java.util.Date(rs.getDate(5).getTime()));
+        status.setStatusUrl(rs.getString(2));
+        status.setStatus(rs.getString(3));
+        status.setLastChecked(new java.util.Date(rs.getDate(4).getTime()));
 
         statuses.add(status);
       }
@@ -81,10 +79,9 @@ public class BulkStatusService {
     try (Connection conn = this.dataSource.getConnection()) {
       assert conn != null;
 
-      String query = "SELECT id, tenantId, statusUrl, [status], [date] FROM [dbo].[bulkStatus] WHERE tenantId = ? AND id = ?";
+      String query = "SELECT id, statusUrl, [status], [date] FROM [dbo].[bulkStatus] WHERE id = ?";
       PreparedStatement ps = conn.prepareStatement(query);
-      ps.setNString(1, tenantConfig.getId());
-      ps.setNString(2, id);
+      ps.setNString(1, id);
 
       ResultSet rs = ps.executeQuery();
 
@@ -94,10 +91,9 @@ public class BulkStatusService {
         status = new BulkStatus();
 
         status.setId(rs.getString(1));
-        status.setTenantId(rs.getString(2));
-        status.setStatusUrl(rs.getString(3));
-        status.setStatus(rs.getString(4));
-        status.setLastChecked(new java.util.Date(rs.getDate(5).getTime()));
+        status.setStatusUrl(rs.getString(2));
+        status.setStatus(rs.getString(3));
+        status.setLastChecked(new java.util.Date(rs.getDate(4).getTime()));
       }
 
       assert status != null;
@@ -148,9 +144,8 @@ public class BulkStatusService {
     try (Connection conn = this.dataSource.getConnection()) {
       assert conn != null;
 
-      SQLCSHelper cs = new SQLCSHelper(conn, "{ CALL saveBulkStatus (?, ?, ?, ?, ?) }");
+      SQLCSHelper cs = new SQLCSHelper(conn, "{ CALL saveBulkStatus (?, ?, ?, ?) }");
       cs.setNString("id", bulkStatus.getId());
-      cs.setNString("tenantId", bulkStatus.getTenantId());
       cs.setNString("status", bulkStatus.getStatus());
       cs.setNString("statusUrl", bulkStatus.getStatusUrl());
       cs.setDateTime("date", bulkStatus.getLastChecked().getTime());
@@ -168,8 +163,7 @@ public class BulkStatusService {
     try (Connection conn = this.dataSource.getConnection()) {
       assert conn != null;
 
-      PreparedStatement ps = conn.prepareStatement("SELECT id, tenantId, statusUrl, [status], [date] FROM [dbo].[bulkStatus] WHERE tenantId = ? AND [status] = 'Pending' AND statusURL IS NOT NULL");
-      ps.setNString(1, tenantConfig.getId());
+      PreparedStatement ps = conn.prepareStatement("SELECT id, statusUrl, [status], [date] FROM [dbo].[bulkStatus] WHERE [status] = 'Pending' AND statusURL IS NOT NULL");
 
       ResultSet rs = ps.executeQuery();
 
@@ -179,10 +173,9 @@ public class BulkStatusService {
         var status = new BulkStatus();
 
         status.setId(rs.getString(1));
-        status.setTenantId(rs.getString(2));
-        status.setStatusUrl(rs.getString(3));
-        status.setStatus(rs.getString(4));
-        status.setLastChecked(new java.util.Date(rs.getDate(5).getTime()));
+        status.setStatusUrl(rs.getString(2));
+        status.setStatus(rs.getString(3));
+        status.setLastChecked(new java.util.Date(rs.getDate(4).getTime()));
 
         statuses.add(status);
       }

--- a/core/src/main/resources/tenant-db.sql
+++ b/core/src/main/resources/tenant-db.sql
@@ -80,40 +80,37 @@ CREATE TABLE dbo.[aggregate]
 GO
 
 IF OBJECT_ID(N'[dbo].[bulkStatus]', N'U') IS NULL
-BEGIN
-    CREATE TABLE [dbo].[bulkStatus](
-        [id] [uniqueidentifier] NOT NULL,
-        [tenantId] [nvarchar](128) NULL,
-        [statusUrl] [nvarchar](max) NULL,
-        [status] [nvarchar](128) NULL,
-        [date] [datetime2] NOT NULL
-        PRIMARY KEY CLUSTERED
-    (
-    [id] ASC
-    )WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON, OPTIMIZE_FOR_SEQUENTIAL_KEY = OFF) ON [PRIMARY]
+    BEGIN
+        CREATE TABLE [dbo].[bulkStatus](
+                                           [id] [uniqueidentifier] NOT NULL,
+                                           [statusUrl] [nvarchar](max) NULL,
+                                           [status] [nvarchar](128) NULL,
+                                           [date] [datetime2] NOT NULL
+                                               PRIMARY KEY CLUSTERED
+                                                   (
+                                                    [id] ASC
+                                                       )WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON, OPTIMIZE_FOR_SEQUENTIAL_KEY = OFF) ON [PRIMARY]
         ) ON [PRIMARY] TEXTIMAGE_ON [PRIMARY]
 
-    ALTER TABLE [dbo].[bulkStatus] ADD  DEFAULT (newid()) FOR [id]
-    ALTER TABLE [dbo].[bulkStatus] ADD  DEFAULT (getdate()) FOR [date]
-    ALTER TABLE [dbo].[bulkStatus]  WITH CHECK ADD FOREIGN KEY([tenantId])
-    REFERENCES [dbo].[tenantConfig] ([id])
-END
+        ALTER TABLE [dbo].[bulkStatus] ADD  DEFAULT (newid()) FOR [id]
+        ALTER TABLE [dbo].[bulkStatus] ADD  DEFAULT (getdate()) FOR [date]
+    END
 GO
 
 IF OBJECT_ID(N'[dbo].[bulkStatusResult]', N'U') IS NULL
-BEGIN
-    CREATE TABLE [dbo].[bulkStatusResult](
-        [id] [uniqueidentifier] NOT NULL,
-        [statusId] [nvarchar](256) NOT NULL,
-        [result] [nvarchar](max) NOT NULL,
-        PRIMARY KEY CLUSTERED
-    (
-    [id] ASC
-    )WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON, OPTIMIZE_FOR_SEQUENTIAL_KEY = OFF) ON [PRIMARY]
+    BEGIN
+        CREATE TABLE [dbo].[bulkStatusResult](
+                                                 [id] [uniqueidentifier] NOT NULL,
+                                                 [statusId] [nvarchar](256) NOT NULL,
+                                                 [result] [nvarchar](max) NOT NULL,
+                                                 PRIMARY KEY CLUSTERED
+                                                     (
+                                                      [id] ASC
+                                                         )WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON, OPTIMIZE_FOR_SEQUENTIAL_KEY = OFF) ON [PRIMARY]
         ) ON [PRIMARY] TEXTIMAGE_ON [PRIMARY]
 
-    ALTER TABLE [dbo].[bulkStatusResult] ADD  DEFAULT (newid()) FOR [id]
-END
+        ALTER TABLE [dbo].[bulkStatusResult] ADD  DEFAULT (newid()) FOR [id]
+    END
 
 DROP PROCEDURE IF EXISTS saveBulkStatusResult
 GO
@@ -125,17 +122,17 @@ CREATE PROCEDURE [dbo].[saveBulkStatusResult]
 AS
 BEGIN
     IF NOT EXISTS(SELECT * FROM dbo.bulkStatusResult t WHERE t.id = @id)
-    BEGIN
-        INSERT INTO dbo.bulkStatusResult(statusId, result)
-        VALUES(@statusId, @result)
-    END
+        BEGIN
+            INSERT INTO dbo.bulkStatusResult(statusId, result)
+            VALUES(@statusId, @result)
+        END
     ELSE
         BEGIN
             UPDATE dbo.bulkStatusResult
             SET statusId = @statusId, result = @result
             WHERE id = @id
         END
-    END
+END
 GO
 
 DROP PROCEDURE IF EXISTS saveBulkStatus
@@ -143,22 +140,21 @@ GO
 
 CREATE PROCEDURE [dbo].[saveBulkStatus]
     @id NVARCHAR(64),
-    @tenantId NVARCHAR(128),
     @statusUrl NVARCHAR(MAX),
     @status NVARCHAR(128),
     @date DateTime2(7)
 AS
 BEGIN
     IF NOT EXISTS(SELECT * FROM dbo.bulkStatus t WHERE t.id = @id)
-    BEGIN
-        INSERT INTO dbo.bulkStatus(tenantId, statusUrl, [status], [date])
-        VALUES(@tenantId, @statusUrl, @status, @date)
-    END
+        BEGIN
+            INSERT INTO dbo.bulkStatus(statusUrl, [status], [date])
+            VALUES(@statusUrl, @status, @date)
+        END
     ELSE
         BEGIN
             UPDATE dbo.bulkStatus
-            SET tenantId = @tenantId, statusUrl = @statusUrl, [status] = @status, [date] = @date
+            SET statusUrl = @statusUrl, [status] = @status, [date] = @date
             WHERE id = @id
         END
-    END
+END
 GO


### PR DESCRIPTION
Remove the concept of the TenantId form the BullkStatus db objects and calls, and tenant-db.sql script.