### PR TITLE
LNK-1406: Change Query Plan configuration to skip supplemental data check when specified

### DIFF
--- a/core/src/main/java/com/lantanagroup/link/events/CopyLocationIdentifierToType.java
+++ b/core/src/main/java/com/lantanagroup/link/events/CopyLocationIdentifierToType.java
@@ -30,8 +30,8 @@ public class CopyLocationIdentifierToType implements IReportGenerationDataEvent 
       if (entry.getResource().getResourceType().equals(ResourceType.Location)) {
         Location locationResource = (Location) entry.getResource();
         //Check for ConceptMap extension indicating that the identifier move to type and ConceptMapping has already been performed on this Location
-        List<CodeableConcept> conceptMapExtensionCheck =
-                locationResource.getType().stream().filter(t ->
+        List<Coding> conceptMapExtensionCheck =
+                locationResource.getType().stream().flatMap(t -> t.getCoding().stream()).filter(t ->
                                 t.getExtension().stream().anyMatch(e -> e.getUrl().equals(Constants.ConceptMappingExtension)))
                         .collect(Collectors.toList());
         //If not already performed, continue

--- a/core/src/main/java/com/lantanagroup/link/model/ReportContext.java
+++ b/core/src/main/java/com/lantanagroup/link/model/ReportContext.java
@@ -3,6 +3,7 @@ package com.lantanagroup.link.model;
 import com.lantanagroup.link.FhirHelper;
 import com.lantanagroup.link.auth.LinkCredentials;
 import com.lantanagroup.link.db.model.PatientList;
+import com.lantanagroup.link.db.model.tenant.QueryPlan;
 import com.lantanagroup.link.query.QueryPhase;
 import lombok.Getter;
 import lombok.Setter;
@@ -23,6 +24,7 @@ public class ReportContext {
   private List<PatientList> patientLists = new ArrayList<>();
   private List<PatientOfInterestModel> patientsOfInterest = new ArrayList<>();
   private List<MeasureContext> measureContexts = new ArrayList<>();
+  private QueryPlan queryPlan;
 
   public ReportContext() {
   }


### PR DESCRIPTION
In some cases, we may only need an initial query/evaluate phase, without a subsequent supplemental phase.  This commit updates `ReportController` to recognize such a case, suppress the supplemental phase, and skip straight to aggregation.