### PR TITLE
Fix query plan encoding

### DIFF
--- a/core/src/main/java/com/lantanagroup/link/FhirBundler.java
+++ b/core/src/main/java/com/lantanagroup/link/FhirBundler.java
@@ -105,10 +105,9 @@ public class FhirBundler {
 
     Yaml yaml = new Yaml();
     String queryPlansYaml = yaml.dump(queryPlans);
-    String queryPlansBase64 = Base64.getEncoder().encodeToString(queryPlansYaml.getBytes(StandardCharsets.UTF_8));
     lib.addContent()
             .setContentType("text/yml")
-            .setData(queryPlansBase64.getBytes(StandardCharsets.UTF_8));
+            .setData(queryPlansYaml.getBytes(StandardCharsets.UTF_8));
 
     return lib;
   }


### PR DESCRIPTION
`Attachment.setData` already takes care of Base64-encoding the supplied byte array.