### PR TITLE
feature/SLNL-46-Loading_resources_data_from_api

### DIFF
--- a/web/src/app/pages/resources/resources.component.html
+++ b/web/src/app/pages/resources/resources.component.html
@@ -5,7 +5,7 @@
 <section>
 	<div class="container py-4">
 		<div class="row">
-			<div *ngFor="let group of resourceGroups"
+			<div *ngFor="let group of ResourceContentsData"
 				class="col col-md-6">
 				<app-card [title]="group.name">
 					<app-resource-contents [resourceSections]="group.sections" />

--- a/web/src/app/pages/resources/resources.component.ts
+++ b/web/src/app/pages/resources/resources.component.ts
@@ -1,9 +1,10 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { CardComponent } from 'src/app/shared/card/card.component';
 import { ResourceContentsComponent } from 'src/app/shared/resource-contents/resource-contents.component';
 import { ResourceGroup } from 'src/app/shared/interfaces/resource-contents.model';
 import { HeroComponent } from 'src/app/shared/hero/hero.component';
+import { DataService } from 'src/services/data.service';
 
 @Component({
   selector: 'app-resources',
@@ -12,10 +13,30 @@ import { HeroComponent } from 'src/app/shared/hero/hero.component';
   templateUrl: './resources.component.html',
   styleUrls: ['./resources.component.scss']
 })
-export class ResourcesComponent {
+export class ResourcesComponent implements OnInit {
+  constructor(private dataService: DataService) { }
+  ResourceContentsData: ResourceGroup[] = [];
 
-  //Test data
-  resourceGroups: ResourceGroup[] = [
+  ngOnInit(): void {
+    this.fetchResourceContents();
+  }
+
+  fetchResourceContents(): void {
+    this.dataService.getData('info').subscribe({
+      next: (data: any) => {
+        this.ResourceContentsData = data as ResourceGroup[];
+      },
+      error: (error) => {
+        console.error('Error fetching resource contents:', error);
+      },
+      complete: () => {
+        console.log('Resource Content fetched Successfully.');
+      }
+    });
+  }
+
+  //TODO: Kepping test data for now but can be removed later.
+  resourceGroupsTestData: ResourceGroup[] = [
     {
       name: 'DQM: INFO, SPECS AND HISTORY',
       sections: [

--- a/web/src/app/shared/resource-contents/resource-contents.component.html
+++ b/web/src/app/shared/resource-contents/resource-contents.component.html
@@ -3,7 +3,7 @@
 	<div class="resource-section-links-container" *ngFor="let link of section.links">
 		<a href="{{ link.url }}"
 			class="resource-link"
-			[target]="link.target ? link.target : '_self'">
+			[target]="link.target ? link.target : '_blank'">
 			{{ link.title }}
 			<img src="assets/icons/externalLink.svg" alt="icon" class="link-icon">
 		</a>


### PR DESCRIPTION
- Rendered data from the api instead of using hardcoded contents.
- set "_blank" value as default link.target value in resource-contents.component.html.
- renamed resourceGroups to ResourceContentsData.