### PR TITLE
fixing a gray

### DIFF
--- a/web/src/app/shared/card/card.component.scss
+++ b/web/src/app/shared/card/card.component.scss
@@ -59,7 +59,7 @@
     
     &--inProgress {
       &::after {
-        background: $in-progress;
+        background: $gray-100;
       }
     }
   }


### PR DESCRIPTION
referencing the wrong color variable on a dashboard card