### PR TITLE
LNK-1845:  Report API to return precise datetime for generatedTime and submittedTime

### DIFF
--- a/core/src/main/java/com/lantanagroup/link/db/SharedService.java
+++ b/core/src/main/java/com/lantanagroup/link/db/SharedService.java
@@ -67,8 +67,8 @@ public class SharedService {
     report.setTenantName(tenantConfig.getName());
     report.setVersion(rs.getString(2));
     report.setStatus(ReportStatuses.valueOf(rs.getString(3)));
-    report.setGeneratedTime(rs.getDate(4));
-    report.setSubmittedTime(rs.getDate(5));
+    report.setGeneratedTime(rs.getTimestamp(4));
+    report.setSubmittedTime(rs.getTimestamp(5));
     report.setPeriodStart(rs.getString(6));
     report.setPeriodEnd(rs.getString(7));
 


### PR DESCRIPTION
Updated the `generatedTime` and `submittedTime` fields to return the timestamp rather than just the date.