### PR TITLE
LNK-1854 Added "vendor" and "otherVendor" to tenant config to support the UI

### DIFF
--- a/api/src/main/java/com/lantanagroup/link/api/controller/TenantController.java
+++ b/api/src/main/java/com/lantanagroup/link/api/controller/TenantController.java
@@ -5,6 +5,7 @@ import com.lantanagroup.link.api.scheduling.Scheduler;
 import com.lantanagroup.link.db.SharedService;
 import com.lantanagroup.link.db.TenantService;
 import com.lantanagroup.link.db.model.tenant.Tenant;
+import com.lantanagroup.link.db.model.tenant.TenantVendors;
 import com.lantanagroup.link.model.SearchTenantResponse;
 import com.lantanagroup.link.model.TenantSummary;
 import com.lantanagroup.link.model.TenantSummaryResponse;
@@ -43,7 +44,7 @@ public class TenantController extends BaseController {
   @GetMapping
   public List<SearchTenantResponse> searchTenants() {
     return this.sharedService.getTenantConfigs().stream()
-            .map(t -> new SearchTenantResponse(t.getId(), t.getName(), t.getRetentionPeriod(), t.getCdcOrgId()))
+            .map(t -> new SearchTenantResponse(t.getId(), t.getName(), t.getRetentionPeriod(), t.getCdcOrgId(), t.getVendor(), t.getOtherVendor()))
             .collect(Collectors.toList());
   }
 
@@ -110,6 +111,10 @@ public class TenantController extends BaseController {
 
     if (StringUtils.isEmpty(newTenantConfig.getTimeZoneId())) {
       newTenantConfig.setTimeZoneId("UTC");
+    }
+
+    if (StringUtils.isNotEmpty(newTenantConfig.getOtherVendor()) && newTenantConfig.getVendor() != TenantVendors.Other) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "If 'otherVendor' is provided, 'vendor' must be 'Other'");
     }
 
     try {

--- a/api/src/main/resources/swagger.yml
+++ b/api/src/main/resources/swagger.yml
@@ -2039,6 +2039,19 @@ components:
         cdcOrgId:
           type: string
           description: 'Organization ID for the tenant according to CDC. Used by the Measure Reporting Plan functionality, and when bundling to submit to NHSN; an Organization resource is created uses this as an identifier of the facility.'
+        vendor:
+          type: string
+          description: The vendor of the EHR system that the tenant uses.
+          enum:
+            - Epic
+            - Cerner
+            - Meditech
+            - Allscripts
+            - Athena
+            - Other
+        otherVendor:
+          type: string
+          description: The name of the vendor if the vendor is not in the list of known vendors. This can only be specified if "vendor" is set to "Other"
     Tenant:
       type: object
       required:
@@ -2054,6 +2067,19 @@ components:
         cdcOrgId:
           type: string
           description: 'Organization ID for the tenant according to CDC. Used by the Measure Reporting Plan functionality, and when bundling to submit to NHSN; an Organization resource is created uses this as an identifier of the facility.'
+        vendor:
+          type: string
+          description: The vendor of the EHR system that the tenant uses.
+          enum:
+            - Epic
+            - Cerner
+            - Meditech
+            - Allscripts
+            - Athena
+            - Other
+        otherVendor:
+          type: string
+          description: The name of the vendor if the vendor is not in the list of known vendors. This can only be specified if "vendor" is set to "Other"
         connectionString:
           type: string
           description: 'The name of the database to use for the tenant''s PHI/PII data. The same connection string for the database server is used for each tenant, but a different database on the server is used for each tenant.'

--- a/core/src/main/java/com/lantanagroup/link/db/model/tenant/Tenant.java
+++ b/core/src/main/java/com/lantanagroup/link/db/model/tenant/Tenant.java
@@ -25,6 +25,16 @@ public class Tenant {
   private String cdcOrgId;
 
   /**
+   * The vendor that the tenant is using. This is used to determine how to query the EHR's FHIR API.
+   */
+  private TenantVendors vendor;
+
+  /**
+   * A free-text string representing the vendor if the vendor is not in the list of known vendors.
+   */
+  private String otherVendor;
+
+  /**
    * A description of the tenant that is more meaningful/useful than the id.
    */
   private String description;

--- a/core/src/main/java/com/lantanagroup/link/db/model/tenant/TenantVendors.java
+++ b/core/src/main/java/com/lantanagroup/link/db/model/tenant/TenantVendors.java
@@ -1,0 +1,10 @@
+package com.lantanagroup.link.db.model.tenant;
+
+public enum TenantVendors {
+  Epic,
+  Cerner,
+  Allscripts,
+  Meditech,
+  Athena,
+  Other
+}

--- a/core/src/main/java/com/lantanagroup/link/model/SearchTenantResponse.java
+++ b/core/src/main/java/com/lantanagroup/link/model/SearchTenantResponse.java
@@ -1,5 +1,6 @@
 package com.lantanagroup.link.model;
 
+import com.lantanagroup.link.db.model.tenant.TenantVendors;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
@@ -12,4 +13,6 @@ public class SearchTenantResponse {
   private String name;
   private String retentionPeriod;
   private String cdcOrgId;
+  private TenantVendors vendor;
+  private String otherVendor;
 }


### PR DESCRIPTION
Ran local tests to PUT/GET existing tenants with "vendor", and ensured that "otherVendor" is only allowed when "vendor" is "Other".