### PR TITLE
Fix `EncounterStatusTransformer`

### DIFF
--- a/core/src/main/java/com/lantanagroup/link/events/EncounterStatusTransformer.java
+++ b/core/src/main/java/com/lantanagroup/link/events/EncounterStatusTransformer.java
@@ -26,9 +26,9 @@ public class EncounterStatusTransformer implements IReportGenerationDataEvent {
         if (patientEncounter.getPeriod().hasEnd() && patientEncounter.getStatus() != Encounter.EncounterStatus.FINISHED) {
           logger.debug("Updating Encounter {} status from {} to FINISHED", patientEncounter.getIdElement().getIdPart(), patientEncounter.getStatus());
 
-          patientEncounter.addExtension()
+          patientEncounter.getStatusElement().addExtension()
                   .setUrl(Constants.OriginalElementValueExtension)
-                  .setValue(new CodeType().setValue(patientEncounter.getStatus().toString()));
+                  .setValue(new CodeType(patientEncounter.getStatus().toCode()));
           patientEncounter.setStatus(Encounter.EncounterStatus.FINISHED);
         }
       }

--- a/nhsn/src/test/java/com/lantanagroup/link/nhsn/EncounterStatusTransformerTest.java
+++ b/nhsn/src/test/java/com/lantanagroup/link/nhsn/EncounterStatusTransformerTest.java
@@ -68,8 +68,8 @@ public class EncounterStatusTransformerTest {
     Encounter encounterTest2 = (Encounter)bundle.getEntry().get(2).getResource();
     //Rewriting these tests to check that the transformed values persist rather than checking that they DON'T persist
     Assert.assertEquals(encounterTest1.getStatus(), Encounter.EncounterStatus.FINISHED);
-    Assert.assertEquals(encounterTest1.getExtension().size(), 1);
+    Assert.assertTrue(encounterTest1.getStatusElement().hasExtension());
     Assert.assertEquals(encounterTest2.getStatus(), Encounter.EncounterStatus.TRIAGED);
-    Assert.assertEquals(encounterTest2.getExtension().size(), 0);
+    Assert.assertFalse(encounterTest2.getStatusElement().hasExtension());
   }
 }


### PR DESCRIPTION
  - Put original value extension on the `status` element rather than the `Encounter` itself.
  - Use `toCode` (the FHIR code value) rather than `toString` (the name of the Java enum instance).