### PR TITLE
New endpoint to get both categories and results together

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -7,3 +7,5 @@
 # Editor-based HTTP Client requests
 /httpRequests/
 /kubernetes-settings.xml
+# GitHub Copilot persisted chat sessions
+/copilot/chatSessions

--- a/api/src/main/java/com/lantanagroup/link/api/controller/ValidationController.java
+++ b/api/src/main/java/com/lantanagroup/link/api/controller/ValidationController.java
@@ -10,9 +10,7 @@ import com.lantanagroup.link.db.mappers.ValidationResultMapper;
 import com.lantanagroup.link.db.model.Report;
 import com.lantanagroup.link.db.model.tenant.ValidationResult;
 import com.lantanagroup.link.db.model.tenant.ValidationResultCategory;
-import com.lantanagroup.link.model.ValidationCategory;
-import com.lantanagroup.link.model.ValidationCategoryResponse;
-import com.lantanagroup.link.model.ValidationCategorySeverities;
+import com.lantanagroup.link.model.*;
 import com.lantanagroup.link.time.StopwatchManager;
 import com.lantanagroup.link.validation.RuleBasedValidationCategory;
 import com.lantanagroup.link.validation.ValidationService;
@@ -383,5 +381,58 @@ public class ValidationController extends BaseController {
     }
 
     return ValidationResultMapper.toOperationOutcome(categoryResults);
+  }
+
+  /**
+   * Retrieves the validation categories and results for a report
+   *
+   * @param tenantId The id of the tenant
+   * @param reportId The id of the report to validate against
+   * @return Returns a ValidationCategoriesAndResults object
+   */
+  @GetMapping(value = "/{tenantId}/{reportId}/category/results", produces = {"application/xml", "application/json"})
+  public ValidationCategoriesAndResults getValidationCategoriesAndResults(@PathVariable String tenantId, @PathVariable String reportId) {
+    TenantService tenantService = TenantService.create(this.sharedService, tenantId);
+
+    if (tenantService == null) {
+      throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Tenant not found");
+    }
+
+    Report report = tenantService.getReport(reportId);
+
+    if (report == null) {
+      throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Report not found");
+    }
+
+    ValidationCategoriesAndResults categoriesAndResults = new ValidationCategoriesAndResults();
+    List<ValidationCategory> categories = ValidationCategorizer.loadAndRetrieveCategories();
+    List<ValidationResult> results = tenantService.getValidationResults(reportId);
+    List<ValidationResultCategory> resultCategories = tenantService.findValidationResultCategoriesByReport(reportId);
+
+    categoriesAndResults.setCategories(categories.stream()
+            .map(c -> {
+              ValidationCategoryResponse response = new ValidationCategoryResponse(c);
+              response.setCount(resultCategories.stream().filter(rc -> rc.getCategoryCode().equals(c.getId())).count());
+              return response;
+            })
+            .filter(c -> c.getCount() > 0)
+            .collect(Collectors.toList()));
+
+    categoriesAndResults.setResults(results.stream().map(r -> {
+      ValidationResultResponse response = new ValidationResultResponse();
+      response.setId(r.getId());
+      response.setCode(r.getCode());
+      response.setDetails(r.getDetails());
+      response.setSeverity(r.getSeverity());
+      response.setExpression(r.getExpression());
+      response.setPosition(r.getPosition());
+      response.setCategories(resultCategories.stream()
+              .filter(rc -> rc.getValidationResultId().equals(r.getId()))
+              .map(ValidationResultCategory::getCategoryCode)
+              .collect(Collectors.toList()));
+      return response;
+    }).collect(Collectors.toList()));
+
+    return categoriesAndResults;
   }
 }

--- a/api/src/main/java/com/lantanagroup/link/api/controller/ValidationController.java
+++ b/api/src/main/java/com/lantanagroup/link/api/controller/ValidationController.java
@@ -390,7 +390,7 @@ public class ValidationController extends BaseController {
    * @param reportId The id of the report to validate against
    * @return Returns a ValidationCategoriesAndResults object
    */
-  @GetMapping(value = "/{tenantId}/{reportId}/category/results", produces = {"application/xml", "application/json"})
+  @GetMapping(value = "/{tenantId}/{reportId}/category/result", produces = {"application/xml", "application/json"})
   public ValidationCategoriesAndResults getValidationCategoriesAndResults(@PathVariable String tenantId, @PathVariable String reportId) {
     TenantService tenantService = TenantService.create(this.sharedService, tenantId);
 

--- a/api/src/main/resources/swagger.yml
+++ b/api/src/main/resources/swagger.yml
@@ -1377,6 +1377,41 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
+  /api/validate/{tenantId}/{reportId}/category/result:
+    get:
+      tags:
+        - Validation
+      summary: Retrieves the validation categories and results for a report
+      operationId: getValidationCategoriesAndResults
+      parameters:
+        - name: tenantId
+          in: path
+          description: The id of the tenant in which the report resides, and used to determine validation options
+          required: true
+          schema:
+            type: string
+        - name: reportId
+          in: path
+          description: The logical id of the report to submit
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: successful response
+          content:
+            'application/xml':
+              schema:
+                $ref: '#/components/schemas/ValidationCategoriesAndResults'
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/ValidationCategoriesAndResults'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
   /api/measureDef:
     get:
       tags:
@@ -2947,6 +2982,8 @@ components:
             type: number
     ValidationCategoryResponse:
       type: object
+      xml:
+        name: category
       description: Information about the validation categories for a report.
       properties:
         id:
@@ -3033,6 +3070,50 @@ components:
         isInverse:
           type: boolean
           description: True if the rule should be inverted (i.e. if the regex matches, the rule fails)
+    ValidationResultResponse:
+      type: object
+      xml:
+        name: result
+      properties:
+        id:
+          type: string
+        reportId:
+          type: string
+        code:
+          type: string
+        details:
+          type: string
+        severity:
+          type: string
+        expression:
+          type: string
+        position:
+          type: string
+        categories:
+          type: array
+          items:
+            type: string
+            xml:
+              name: category
+          xml:
+            wrapped: true
+    ValidationCategoriesAndResults:
+      type: object
+      xml:
+        name: validation
+      properties:
+        categories:
+          type: array
+          items:
+            $ref: '#/components/schemas/ValidationCategoryResponse'
+          xml:
+            wrapped: true
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/ValidationResultResponse'
+          xml:
+            wrapped: true
   securitySchemes:
     oauth:
       type: oauth2

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -67,6 +67,11 @@
             <artifactId>hapi-fhir-client</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-xml</artifactId>
+            <version>2.16.1</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter</artifactId>
         </dependency>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -69,7 +69,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-xml</artifactId>
-            <version>2.16.1</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/core/src/main/java/com/lantanagroup/link/model/ValidationCategoriesAndResults.java
+++ b/core/src/main/java/com/lantanagroup/link/model/ValidationCategoriesAndResults.java
@@ -1,0 +1,23 @@
+package com.lantanagroup.link.model;
+
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Setter
+@JacksonXmlRootElement(localName = "validation")
+public class ValidationCategoriesAndResults {
+  @JacksonXmlProperty(localName = "category")
+  @JacksonXmlElementWrapper(localName = "categories")
+  public List<ValidationCategoryResponse> categories = new ArrayList<>();
+
+  @JacksonXmlProperty(localName = "result")
+  @JacksonXmlElementWrapper(localName = "results")
+  public List<ValidationResultResponse> results = new ArrayList<>();
+}

--- a/core/src/main/java/com/lantanagroup/link/model/ValidationResultResponse.java
+++ b/core/src/main/java/com/lantanagroup/link/model/ValidationResultResponse.java
@@ -1,0 +1,20 @@
+package com.lantanagroup.link.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import com.lantanagroup.link.db.model.tenant.ValidationResult;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ValidationResultResponse extends ValidationResult {
+
+  @JacksonXmlProperty(localName = "category")
+  @JacksonXmlElementWrapper(localName = "categories")
+  private List<String> categories;
+}


### PR DESCRIPTION
... together in a single request/response/file where an .XSLT *could* be used to convert it into an .html file that can be shared with stakeholders (something similar is already occuring, but with "valview" python scripts that I'd like to deprecate the use of.