### PR TITLE
Bump `rc_0.4.0` version

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>link</artifactId>
         <groupId>com.lantanagroup.link</groupId>
-        <version>0.3.3-SNAPSHOT</version>
+        <version>0.4.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>link</artifactId>
         <groupId>com.lantanagroup.link</groupId>
-        <version>0.3.3-SNAPSHOT</version>
+        <version>0.4.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nhsn/pom.xml
+++ b/nhsn/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>link</artifactId>
         <groupId>com.lantanagroup.link</groupId>
-        <version>0.3.3-SNAPSHOT</version>
+        <version>0.4.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <groupId>com.lantanagroup.link</groupId>
     <artifactId>link</artifactId>
     <packaging>pom</packaging>
-    <version>0.3.3-SNAPSHOT</version>
+    <version>0.4.0-SNAPSHOT</version>
 
     <modules>
         <module>core</module>

--- a/query/pom.xml
+++ b/query/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>link</artifactId>
         <groupId>com.lantanagroup.link</groupId>
-        <version>0.3.3-SNAPSHOT</version>
+        <version>0.4.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
@sdmcgeown, FYI, this bumps the versions in our POMs ... something I neglected to do in preparation for the 0.4.0 RC.  I think we'd ideally use the [Maven Release Plugin](https://maven.apache.org/maven-release/maven-release-plugin/) for this sort of thing, but thus far we've done it in a more ad hoc fashion.

Separate PR incoming for the `development` branch, which will be bumped to `0.4.1-SNAPSHOT`.