### PR TITLE
LNK-2866: Implement code fix for handling FHIR references expressed as absolute URLs

### DIFF
--- a/core/src/main/java/com/lantanagroup/link/ReferenceRelativizer.java
+++ b/core/src/main/java/com/lantanagroup/link/ReferenceRelativizer.java
@@ -1,0 +1,48 @@
+package com.lantanagroup.link;
+
+import ca.uhn.fhir.context.FhirContext;
+import org.apache.commons.lang3.StringUtils;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.r4.model.IdType;
+import org.hl7.fhir.r4.model.Reference;
+
+import java.util.List;
+
+public class ReferenceRelativizer {
+  private final FhirContext fhirContext;
+
+  public ReferenceRelativizer(FhirContext fhirContext) {
+    this.fhirContext = fhirContext;
+  }
+
+  /**
+   * Removes the base URL portion of references in the specified resource.
+   * If a non-null expected base URL is specified, relativizes only matching references.
+   * Otherwise, relativizes all references.
+   */
+  public void relativize(IBaseResource resource, String expectedBaseUrl) {
+    String cleanExpectedBaseUrl = expectedBaseUrl == null ? null : StringUtils.stripEnd(expectedBaseUrl, "/");
+    List<Reference> references = fhirContext.newTerser().getAllPopulatedChildElementsOfType(resource, Reference.class);
+    for (Reference reference : references) {
+      String referenceElement = reference.getReference();
+      if (StringUtils.isEmpty(referenceElement)) {
+        continue;
+      }
+      IdType referenceId = new IdType(referenceElement);
+      String referenceBaseUrl = referenceId.getBaseUrl();
+      if (referenceBaseUrl == null) {
+        continue;
+      }
+      if (cleanExpectedBaseUrl == null || StringUtils.equals(referenceBaseUrl, cleanExpectedBaseUrl)) {
+        reference.setReference(referenceId.toUnqualified().getValue());
+      }
+    }
+  }
+
+  /**
+   * Removes the base URL portion of references in the specified resource.
+   */
+  public void relativize(IBaseResource resource) {
+    relativize(resource, null);
+  }
+}

--- a/core/src/main/java/com/lantanagroup/link/ReferenceRelativizer.java
+++ b/core/src/main/java/com/lantanagroup/link/ReferenceRelativizer.java
@@ -1,19 +1,39 @@
 package com.lantanagroup.link;
 
 import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.util.FhirTerser;
 import org.apache.commons.lang3.StringUtils;
 import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.IdType;
 import org.hl7.fhir.r4.model.Reference;
 import org.hl7.fhir.r4.model.StringType;
 
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 public class ReferenceRelativizer {
   private final FhirContext fhirContext;
 
   public ReferenceRelativizer(FhirContext fhirContext) {
     this.fhirContext = fhirContext;
+  }
+
+  private List<Reference> getReferences(IBaseResource resource) {
+    List<IBaseResource> resources;
+    if (resource instanceof Bundle) {
+      resources = ((Bundle) resource).getEntry().stream()
+              .map(Bundle.BundleEntryComponent::getResource)
+              .filter(Objects::nonNull)
+              .collect(Collectors.toList());
+    } else {
+      resources = List.of(resource);
+    }
+    FhirTerser fhirTerser = fhirContext.newTerser();
+    return resources.stream()
+            .flatMap(_resource -> fhirTerser.getAllPopulatedChildElementsOfType(_resource, Reference.class).stream())
+            .collect(Collectors.toList());
   }
 
   /**
@@ -23,8 +43,7 @@ public class ReferenceRelativizer {
    */
   public void relativize(IBaseResource resource, String expectedBaseUrl) {
     String cleanExpectedBaseUrl = expectedBaseUrl == null ? null : StringUtils.stripEnd(expectedBaseUrl, "/");
-    List<Reference> references = fhirContext.newTerser().getAllPopulatedChildElementsOfType(resource, Reference.class);
-    for (Reference reference : references) {
+    for (Reference reference : getReferences(resource)) {
       String referenceElement = reference.getReference();
       if (StringUtils.isEmpty(referenceElement)) {
         continue;

--- a/core/src/main/java/com/lantanagroup/link/ReferenceRelativizer.java
+++ b/core/src/main/java/com/lantanagroup/link/ReferenceRelativizer.java
@@ -5,6 +5,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r4.model.IdType;
 import org.hl7.fhir.r4.model.Reference;
+import org.hl7.fhir.r4.model.StringType;
 
 import java.util.List;
 
@@ -34,6 +35,9 @@ public class ReferenceRelativizer {
         continue;
       }
       if (cleanExpectedBaseUrl == null || StringUtils.equals(referenceBaseUrl, cleanExpectedBaseUrl)) {
+        reference.addExtension()
+                .setUrl(Constants.OriginalElementValueExtension)
+                .setValue(new StringType(referenceElement));
         reference.setReference(referenceId.toUnqualified().getValue());
       }
     }

--- a/core/src/main/java/com/lantanagroup/link/events/RelativizeReferences.java
+++ b/core/src/main/java/com/lantanagroup/link/events/RelativizeReferences.java
@@ -1,0 +1,25 @@
+package com.lantanagroup.link.events;
+
+import com.lantanagroup.link.FhirContextProvider;
+import com.lantanagroup.link.IReportGenerationDataEvent;
+import com.lantanagroup.link.ReferenceRelativizer;
+import com.lantanagroup.link.db.TenantService;
+import com.lantanagroup.link.model.ReportContext;
+import com.lantanagroup.link.model.ReportCriteria;
+import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.DomainResource;
+
+import java.util.List;
+
+public class RelativizeReferences implements IReportGenerationDataEvent {
+  @Override
+  public void execute(TenantService tenantService, Bundle data, ReportCriteria criteria, ReportContext context, ReportContext.MeasureContext measureContext) {
+    ReferenceRelativizer relativizer = new ReferenceRelativizer(FhirContextProvider.getFhirContext());
+    String baseUrl = tenantService.getConfig().getFhirQuery().getFhirServerBase();
+    relativizer.relativize(data, baseUrl);
+  }
+
+  @Override
+  public void execute(TenantService tenantService, List<DomainResource> data, ReportCriteria criteria, ReportContext context, ReportContext.MeasureContext measureContext) {
+  }
+}

--- a/core/src/test/java/com/lantanagroup/link/ReferenceRelativizerTests.java
+++ b/core/src/test/java/com/lantanagroup/link/ReferenceRelativizerTests.java
@@ -1,0 +1,57 @@
+package com.lantanagroup.link;
+
+import org.hl7.fhir.r4.model.ListResource;
+import org.hl7.fhir.r4.model.Reference;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertArrayEquals;
+
+public class ReferenceRelativizerTests {
+  private final ReferenceRelativizer referenceRelativizer;
+  private final List<String> references = List.of(
+          "Patient/1",
+          "https://foo/fhir/Patient/2",
+          "https://bar/fhir/Patient/3");
+  private ListResource list;
+
+  public ReferenceRelativizerTests() {
+    referenceRelativizer = new ReferenceRelativizer(FhirContextProvider.getFhirContext());
+  }
+
+  @Before
+  public void initializeList() {
+    list = new ListResource();
+    for (String reference : references) {
+      list.addEntry().getItem().setReference(reference);
+    }
+  }
+
+  private void doTest(String... expectedReferences) {
+    String[] actualReferences = list.getEntry().stream()
+            .map(ListResource.ListEntryComponent::getItem)
+            .map(Reference::getReference)
+            .toArray(String[]::new);
+    assertArrayEquals(expectedReferences, actualReferences);
+  }
+
+  @Test
+  public void testRelativizeWithNonNullExpectedBaseUrl() {
+    referenceRelativizer.relativize(list, "https://foo/fhir");
+    doTest("Patient/1", "Patient/2", "https://bar/fhir/Patient/3");
+  }
+
+  @Test
+  public void testRelativizeWithNonNullExpectedBaseUrlAndTrailingSlash() {
+    referenceRelativizer.relativize(list, "https://foo/fhir/");
+    doTest("Patient/1", "Patient/2", "https://bar/fhir/Patient/3");
+  }
+
+  @Test
+  public void testRelativizeWithNullExpectedBaseUrl() {
+    referenceRelativizer.relativize(list, null);
+    doTest("Patient/1", "Patient/2", "Patient/3");
+  }
+}

--- a/core/src/test/java/com/lantanagroup/link/ReferenceRelativizerTests.java
+++ b/core/src/test/java/com/lantanagroup/link/ReferenceRelativizerTests.java
@@ -5,16 +5,20 @@ import org.hl7.fhir.r4.model.Reference;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.List;
-
 import static org.junit.Assert.assertArrayEquals;
 
 public class ReferenceRelativizerTests {
   private final ReferenceRelativizer referenceRelativizer;
-  private final List<String> references = List.of(
+  private final String[] references = new String[]{
           "Patient/1",
           "https://foo/fhir/Patient/2",
-          "https://bar/fhir/Patient/3");
+          "https://bar/fhir/Patient/3",
+          "#4",
+          "https://foo/fhir/Patient/5/_history/1",
+          "https://bar/fhir/Patient/6/_history/1",
+          "https://ƀäž/fhir/Patient/7",
+          null
+  };
   private ListResource list;
 
   public ReferenceRelativizerTests() {
@@ -40,18 +44,42 @@ public class ReferenceRelativizerTests {
   @Test
   public void testRelativizeWithNonNullExpectedBaseUrl() {
     referenceRelativizer.relativize(list, "https://foo/fhir");
-    doTest("Patient/1", "Patient/2", "https://bar/fhir/Patient/3");
+    doTest(
+            "Patient/1",
+            "Patient/2",
+            "https://bar/fhir/Patient/3",
+            "#4",
+            "Patient/5/_history/1",
+            "https://bar/fhir/Patient/6/_history/1",
+            "https://ƀäž/fhir/Patient/7",
+            null);
   }
 
   @Test
   public void testRelativizeWithNonNullExpectedBaseUrlAndTrailingSlash() {
     referenceRelativizer.relativize(list, "https://foo/fhir/");
-    doTest("Patient/1", "Patient/2", "https://bar/fhir/Patient/3");
+    doTest(
+            "Patient/1",
+            "Patient/2",
+            "https://bar/fhir/Patient/3",
+            "#4",
+            "Patient/5/_history/1",
+            "https://bar/fhir/Patient/6/_history/1",
+            "https://ƀäž/fhir/Patient/7",
+            null);
   }
 
   @Test
   public void testRelativizeWithNullExpectedBaseUrl() {
     referenceRelativizer.relativize(list, null);
-    doTest("Patient/1", "Patient/2", "Patient/3");
+    doTest(
+            "Patient/1",
+            "Patient/2",
+            "Patient/3",
+            "#4",
+            "Patient/5/_history/1",
+            "Patient/6/_history/1",
+            "Patient/7",
+            null);
   }
 }

--- a/query/src/main/java/com/lantanagroup/link/query/uscore/PatientScoop.java
+++ b/query/src/main/java/com/lantanagroup/link/query/uscore/PatientScoop.java
@@ -189,10 +189,9 @@ public class PatientScoop {
         MDC.setContextMap(contextMapCopy);
         logger.debug(String.format("Beginning to load data for patient with logical ID %s", patient.getIdElement().getIdPart()));
 
-        PatientData patientData = null;
-
         try {
-          patientData = this.loadInitialPatientData(criteria, context, patient);
+          PatientData patientData = this.loadInitialPatientData(criteria, context, patient);
+          this.storePatientData(criteria, context, patient.getIdElement().getIdPart(), patientData.getBundle());
         } catch (Exception ex) {
           logger.error("Error loading patient data for patient {}: {}", patient.getId(), ex.getMessage(), ex);
           return null;
@@ -201,8 +200,6 @@ public class PatientScoop {
           double percent = (completed * 100.0) / patients.size();
           logger.info("Progress ({}%) for Initial Patient Data {} is {} of {}", String.format("%.1f", percent), context.getMasterIdentifierValue(), completed, patients.size());
         }
-
-        this.storePatientData(criteria, context, patient.getIdElement().getIdPart(), patientData.getBundle());
 
         return patient.getIdElement().getIdPart();
       }).collect(Collectors.toList())).get();
@@ -221,11 +218,10 @@ public class PatientScoop {
         MDC.setContextMap(contextMapCopy);
         logger.debug(String.format("Continuing to load data for patient with logical ID %s", poi.getId()));
 
-        Bundle patientBundle = com.lantanagroup.link.db.model.PatientData.asBundle(this.tenantService.findPatientData(context.getMasterIdentifierValue(), poi.getId()));
-        PatientData patientData = null;
-
         try {
-          patientData = this.loadSupplementalPatientData(criteria, context, poi.getId(), patientBundle);
+          Bundle patientBundle = com.lantanagroup.link.db.model.PatientData.asBundle(this.tenantService.findPatientData(context.getMasterIdentifierValue(), poi.getId()));
+          PatientData patientData = this.loadSupplementalPatientData(criteria, context, poi.getId(), patientBundle);
+          this.storePatientData(criteria, context, poi.getId(), patientData.getBundle());
         } catch (Exception ex) {
           logger.error("Error loading patient data for patient {}: {}", poi.getId(), ex.getMessage(), ex);
           return null;
@@ -234,8 +230,6 @@ public class PatientScoop {
           double percent = (completed * 100.0) / patientsOfInterest.size();
           logger.info("Progress ({}%) for Supplemental Patient Data {} is {} of {}", String.format("%.1f", percent), context.getMasterIdentifierValue(), completed, patientsOfInterest.size());
         }
-
-        this.storePatientData(criteria, context, poi.getId(), patientData.getBundle());
 
         return poi.getId();
       }).collect(Collectors.toList())).get();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced the `ReferenceRelativizer` class for enhanced handling of FHIR references, allowing for flexible relativization based on base URLs.
	- Added the `RelativizeReferences` class to process FHIR data and relativize references in report generation contexts.

- **Bug Fixes**
	- Improved the logic in the patient data loading process to ensure proper variable scoping and reduce redundant data storage calls.

- **Tests**
	- Added a test suite for `ReferenceRelativizer` to validate the functionality of the relativization process under various scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->