### PR TITLE
LNK-2874: Deduplicate Shared Resources by moving them into their own file during submission.

### DIFF
--- a/core/src/main/java/com/lantanagroup/link/Submission.java
+++ b/core/src/main/java/com/lantanagroup/link/Submission.java
@@ -16,6 +16,7 @@ public class Submission {
   public static final String CENSUS = "census.json";
   public static final String AGGREGATE = "aggregate-%s.json";
   public static final String PATIENT = "patient-%s.json";
+  public static final String SHARED = "shared-resources.json";
   public static final String VALIDATION = "validation-%s.json";
   public static final String PRE_QUAL = "validation.html";
 

--- a/core/src/main/java/com/lantanagroup/link/db/model/tenant/Bundling.java
+++ b/core/src/main/java/com/lantanagroup/link/db/model/tenant/Bundling.java
@@ -3,6 +3,9 @@ package com.lantanagroup.link.db.model.tenant;
 import lombok.Getter;
 import lombok.Setter;
 import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.ResourceType;
+
+import java.util.List;
 
 @Getter
 @Setter
@@ -61,4 +64,12 @@ public class Bundling {
    * Bundle's Organization.name field
    */
   private Address address;
+
+  /**
+   * Resource types that will be moved from patient-specific bundles into a separate file during folder submission.
+   * Such resources will be deduplicated based on ID.
+   */
+  private List<String> sharedResourceTypes = List.of(
+          ResourceType.Location.name(),
+          ResourceType.Medication.name());
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced enhanced resource management capabilities, allowing for better handling of shared resources during submissions.
	- Added a new constant for identifying shared resources, facilitating integration across the application.
	- Implemented a mechanism to deduplicate specific resource types from patient-specific bundles.

- **Bug Fixes**
	- Improved validation checks for shared resources to ensure they are correctly managed and logged.

- **Documentation**
	- Updated comments and documentation to reflect changes in resource handling and new functionalities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->