### PR TITLE
IMPS-323: Adding in some logic to massage the data stored by HCA (Ver…

### DIFF
--- a/api/src/main/java/com/lantanagroup/link/api/MeasureEvaluator.java
+++ b/api/src/main/java/com/lantanagroup/link/api/MeasureEvaluator.java
@@ -63,20 +63,6 @@ public class MeasureEvaluator {
 
     logger.info("Executing $evaluate-measure for measure: {}, start: {}, end: {}, patient: {}, resources: {}", measureId, criteria.getPeriodStart(), criteria.getPeriodEnd(), patientId, patientBundle.getEntry().size());
 
-    patientBundle.getEntry().forEach(e -> {
-      List<Reference> references = FhirHelper.collect(e.getResource(), Reference.class);
-      references.forEach(r -> {
-        String url = r.getReference();
-        String firstPart = url.substring(0, url.lastIndexOf("/"));
-        //Assume that all references have AT LEAST 1 '/' in it. Do nothing if there's only 1 '/'
-        if(firstPart.lastIndexOf("/") != -1) {
-          String relativeUrl = url.substring(firstPart.lastIndexOf("/") + 1);
-          r.setReference(relativeUrl);
-        }
-      });
-
-    });
-
     //noinspection unused
     try (Stopwatch stopwatch = this.stopwatchManager.start(Constants.TASK_MEASURE, Constants.CATEGORY_EVALUATE)) {
       measureReport = measureServiceWrapper.evaluate(this.criteria.getPeriodStart(), this.criteria.getPeriodEnd(), patientId, patientBundle);

--- a/core/src/main/java/com/lantanagroup/link/db/model/tenant/Tenant.java
+++ b/core/src/main/java/com/lantanagroup/link/db/model/tenant/Tenant.java
@@ -40,7 +40,8 @@ public class Tenant {
   private String description;
 
   /**
-   * Parameter that indicates that some operations will be slightly modified to work for querying Veradigm databases
+   * Parameter that indicates that some operations will be slightly modified to work for querying Veradigm databases.
+   * Defaulted to false.
    */
   private Boolean isVeradigm = false;
 

--- a/core/src/main/java/com/lantanagroup/link/db/model/tenant/Tenant.java
+++ b/core/src/main/java/com/lantanagroup/link/db/model/tenant/Tenant.java
@@ -40,6 +40,11 @@ public class Tenant {
   private String description;
 
   /**
+   * Parameter that indicates that some operations will be slightly modified to work for querying Veradigm databases
+   */
+  private Boolean isVeradigm = false;
+
+  /**
    * The Time Zone string for the Tenant
    */
   private String timeZoneId;

--- a/query/src/main/java/com/lantanagroup/link/query/uscore/PatientData.java
+++ b/query/src/main/java/com/lantanagroup/link/query/uscore/PatientData.java
@@ -22,6 +22,8 @@ import org.hl7.fhir.r4.model.*;
 import org.hl7.fhir.r4.model.Bundle.BundleType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import java.time.format.DateTimeFormatter;
+import java.time.ZoneOffset;
 
 import java.time.Period;
 import java.util.*;
@@ -84,6 +86,10 @@ public class PatientData {
     logResourceTypeCounts();
   }
 
+  private SearchStyleEnum getSearchStyle(){
+    return this.tenantService.getConfig().getIsVeradigm() ? SearchStyleEnum.GET : SearchStyleEnum.POST;
+  }
+
   private void search(TypedQueryPlan plan) {
     logger.info("Querying for patient {} and resource type {}", patientId, plan.getResourceType());
     try (Stopwatch stopwatch = stopwatchManager.start(plan.getResourceType(), Constants.CATEGORY_QUERY)) {
@@ -133,7 +139,7 @@ public class PatientData {
         String joinedIds = String.join(",", ids);
         IQuery<Bundle> query = fhirQueryServer.search()
                 .forResource(resourceType)
-                .usingStyle((this.tenantService.getConfig().getIsVeradigm() ? SearchStyleEnum.GET : SearchStyleEnum.POST))
+                .usingStyle(getSearchStyle())
                 .whereMap(Map.of(pagedName, List.of(joinedIds)))
                 .whereMap(unpagedMap)
                 .returnBundle(Bundle.class);
@@ -169,7 +175,7 @@ public class PatientData {
           for (List<String> ids : pagedIds) {
             IQuery<Bundle> query = fhirQueryServer.search()
                     .forResource(resourceType)
-                    .usingStyle((this.tenantService.getConfig().getIsVeradigm() ? SearchStyleEnum.GET : SearchStyleEnum.POST))
+                    .usingStyle(getSearchStyle())
                     .where(Resource.RES_ID.exactly().codes(ids))
                     .returnBundle(Bundle.class);
             addAllResources(query);
@@ -177,7 +183,7 @@ public class PatientData {
         } else {
           IQuery<Bundle> query = fhirQueryServer.search()
                   .forResource(resourceType)
-                  .usingStyle((this.tenantService.getConfig().getIsVeradigm() ? SearchStyleEnum.GET : SearchStyleEnum.POST))
+                  .usingStyle(getSearchStyle())
                   .where(Resource.RES_ID.exactly().codes(unpagedIds))
                   .returnBundle(Bundle.class);
           addAllResources(query);
@@ -213,11 +219,23 @@ public class PatientData {
         return patientId;
       case "lookbackstart":
         Period lookback = Period.parse(context.getQueryPlan().getLookback());
-        return criteria.getPeriodStartDate().minus(lookback) + (this.tenantService.getConfig().getIsVeradigm() ? "" : "T00:00:00Z");
+        if (this.tenantService.getConfig().getIsVeradigm()) {
+            return criteria.getPeriodStartDate().minus(lookback).format(DateTimeFormatter.ISO_LOCAL_DATE);
+        } else {
+            return criteria.getPeriodStartDate().minus(lookback).atStartOfDay(ZoneOffset.UTC).format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+        }
       case "periodstart":
-        return criteria.getPeriodStartDate().toString() + (this.tenantService.getConfig().getIsVeradigm() ? "" : "T00:00:00Z");
+        if (this.tenantService.getConfig().getIsVeradigm()) {
+            return criteria.getPeriodStartDate().format(DateTimeFormatter.ISO_LOCAL_DATE);
+        } else {
+            return criteria.getPeriodStartDate().atStartOfDay(ZoneOffset.UTC).format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+        }
       case "periodend":
-        return criteria.getPeriodEndDate().toString() + (this.tenantService.getConfig().getIsVeradigm() ? "" : "T23:59:59Z");
+        if (this.tenantService.getConfig().getIsVeradigm()) {
+            return criteria.getPeriodEndDate().format(DateTimeFormatter.ISO_LOCAL_DATE);
+        } else {
+            return criteria.getPeriodEndDate().atTime(23, 59, 59).atOffset(ZoneOffset.UTC).format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+        }
       default:
         throw new IllegalStateException("Unrecognized parameter variable: " + variable);
     }

--- a/query/src/main/java/com/lantanagroup/link/query/uscore/PatientData.java
+++ b/query/src/main/java/com/lantanagroup/link/query/uscore/PatientData.java
@@ -133,7 +133,7 @@ public class PatientData {
         String joinedIds = String.join(",", ids);
         IQuery<Bundle> query = fhirQueryServer.search()
                 .forResource(resourceType)
-                .usingStyle(SearchStyleEnum.POST)
+                .usingStyle((this.tenantService.getConfig().getIsVeradigm() ? SearchStyleEnum.GET : SearchStyleEnum.POST))
                 .whereMap(Map.of(pagedName, List.of(joinedIds)))
                 .whereMap(unpagedMap)
                 .returnBundle(Bundle.class);
@@ -169,7 +169,7 @@ public class PatientData {
           for (List<String> ids : pagedIds) {
             IQuery<Bundle> query = fhirQueryServer.search()
                     .forResource(resourceType)
-                    .usingStyle(SearchStyleEnum.POST)
+                    .usingStyle((this.tenantService.getConfig().getIsVeradigm() ? SearchStyleEnum.GET : SearchStyleEnum.POST))
                     .where(Resource.RES_ID.exactly().codes(ids))
                     .returnBundle(Bundle.class);
             addAllResources(query);
@@ -177,7 +177,7 @@ public class PatientData {
         } else {
           IQuery<Bundle> query = fhirQueryServer.search()
                   .forResource(resourceType)
-                  .usingStyle(SearchStyleEnum.POST)
+                  .usingStyle((this.tenantService.getConfig().getIsVeradigm() ? SearchStyleEnum.GET : SearchStyleEnum.POST))
                   .where(Resource.RES_ID.exactly().codes(unpagedIds))
                   .returnBundle(Bundle.class);
           addAllResources(query);
@@ -213,11 +213,11 @@ public class PatientData {
         return patientId;
       case "lookbackstart":
         Period lookback = Period.parse(context.getQueryPlan().getLookback());
-        return criteria.getPeriodStartDate().minus(lookback) + "T00:00:00Z";
+        return criteria.getPeriodStartDate().minus(lookback) + (this.tenantService.getConfig().getIsVeradigm() ? "" : "T00:00:00Z");
       case "periodstart":
-        return criteria.getPeriodStartDate().toString() + "T00:00:00Z";
+        return criteria.getPeriodStartDate().toString() + (this.tenantService.getConfig().getIsVeradigm() ? "" : "T00:00:00Z");
       case "periodend":
-        return criteria.getPeriodEndDate().toString() + "T23:59:59Z";
+        return criteria.getPeriodEndDate().toString() + (this.tenantService.getConfig().getIsVeradigm() ? "" : "T23:59:59Z");
       default:
         throw new IllegalStateException("Unrecognized parameter variable: " + variable);
     }


### PR DESCRIPTION
…adigm databases) to be able to be run through measure evaluation.  This includes removing the base URL from references (measure can't determine which resources pertain to the patient being looked at), performing a GET rather than a POST for searching (Veradigm only), and removing all times from start/end dates from queries (Veradigm only).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced measure report generation by ensuring resource references are correctly formatted.
	- Added support for Veradigm tenant configurations in search methods, allowing for flexible query handling.
	- Updated date formatting to align with Veradigm tenant requirements.

- **Bug Fixes**
	- Improved logic for determining search styles based on tenant configuration.

- **Chores**
	- Introduced a new property in the Tenant class to support Veradigm operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->