### PR TITLE
LNK-3094: Allow tenant-specific configuration for the number of query threads (MVP)

### DIFF
--- a/core/src/main/java/com/lantanagroup/link/db/model/tenant/FhirQuery.java
+++ b/core/src/main/java/com/lantanagroup/link/db/model/tenant/FhirQuery.java
@@ -20,6 +20,11 @@ public class FhirQuery {
   private String authClass;
 
   /**
+   * The number of patients to query for in parallel using separate threads.
+   */
+  private int queryThreads = 4;
+
+  /**
    * Configuration used by BasicAuth implementation
    */
   private BasicAuth basicAuth;


### PR DESCRIPTION
Intentionally renamed the relevant tenant config property (from `parallelPatients` to `queryThreads`) to ensure that we don't use our traditional default of 16, which has been problematic for sites.  Also changed `PatientScoop` to prototype scope, since we use it in a tenant-specific fashion, and therefore singleton scope isn't appropriate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new field for parallel patient querying in the FhirQuery class.
	- Enhanced concurrency control in the PatientScoop class for improved patient data retrieval.

- **Improvements**
	- Updated logging for clearer progress tracking during patient data loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->