### PR TITLE
Move cache initialization to `apiInit`

### DIFF
--- a/api/src/main/java/com/lantanagroup/link/api/ApiApplication.java
+++ b/api/src/main/java/com/lantanagroup/link/api/ApiApplication.java
@@ -47,7 +47,6 @@ public class ApiApplication extends SpringBootServletInitializer implements Init
    * @param args
    */
   public static void main(String[] args) {
-    initializeCacheFactory();
     SpringApplication.run(ApiApplication.class, args);
   }
 
@@ -85,6 +84,7 @@ public class ApiApplication extends SpringBootServletInitializer implements Init
    */
   @Bean(initMethod = "init")
   public ApiInit apiInit() {
+    initializeCacheFactory();
     TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
     return new ApiInit();
   }


### PR DESCRIPTION
`ApiApplication.main` isn't invoked when running in a servlet container, which impacts our Docker images.  Move cache initialization to `apiInit` to ensure it occurs regardless of deployment method.