### PR TITLE
LEGEX-89: Update to FhirBundler to account for update to HAPI which n…

### DIFF
--- a/core/src/main/java/com/lantanagroup/link/FhirBundler.java
+++ b/core/src/main/java/com/lantanagroup/link/FhirBundler.java
@@ -570,10 +570,10 @@ public class FhirBundler {
 
     // Clean up the contained resources within the measure report
     individualMeasureReport.getContained().stream()
-            .filter(c -> c.hasId() && c.getIdElement().getIdPart().startsWith("#LCR-"))
+            .filter(c -> c.hasId() && c.getIdElement().getIdPart().startsWith("LCR-"))
             .forEach(c -> {
               // Remove the LCR- prefix added by CQL
-              c.setId(c.getIdElement().getIdPart().substring(5));
+              c.setId(c.getIdElement().getIdPart().substring(4));
 
               // Update references to the evaluated resource to point to the contained reference (for validation purposes)
               individualMeasureReport.getEvaluatedResource().stream()


### PR DESCRIPTION
…o longer appends # to results returned from getIdElement

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of contained resource identifiers to ensure accurate normalization and reference processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->